### PR TITLE
Fix SDK updates

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2,7 +2,7 @@ module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 5868:
+/***/ 424:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -33,10 +33,10 @@ exports.DotNetSdkUpdater = void 0;
 const fs = __importStar(__webpack_require__(5747));
 const os = __importStar(__webpack_require__(2087));
 const path = __importStar(__webpack_require__(5622));
-const core = __webpack_require__(8298);
-const exec = __webpack_require__(5245);
-const github = __webpack_require__(7534);
-const http_client_1 = __webpack_require__(544);
+const core = __webpack_require__(2507);
+const exec = __webpack_require__(6995);
+const github = __webpack_require__(2621);
+const http_client_1 = __webpack_require__(1404);
 const stream_1 = __webpack_require__(2413);
 class DotNetSdkUpdater {
     constructor(options) {
@@ -200,9 +200,30 @@ class DotNetSdkUpdater {
     }
     static getReleaseForSdk(sdkVersion, releaseInfo) {
         let releases = releaseInfo["releases"];
-        const foundRelease = releases.filter((info) => {
-            return info["sdk"]["version"] === sdkVersion;
+        let foundSdk = null;
+        let foundRelease = releases.filter((info) => {
+            const sdk = info["sdk"];
+            if (sdk["version"] === sdkVersion) {
+                foundSdk = sdk;
+                return true;
+            }
+            return false;
         });
+        if (foundRelease.length < 1) {
+            foundRelease = releases.filter((info) => {
+                const sdks = info["sdks"];
+                if (sdks !== null) {
+                    for (let i = 0; i < sdks.length; i++) {
+                        const sdk = sdks[i];
+                        if (sdk["version"] === sdkVersion) {
+                            foundSdk = sdk;
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            });
+        }
         if (foundRelease.length < 1) {
             throw new Error(`Failed to find release for .NET SDK version ${sdkVersion}`);
         }
@@ -210,7 +231,7 @@ class DotNetSdkUpdater {
         const result = {
             releaseNotes: release["release-notes"],
             runtimeVersion: release["runtime"]["version"],
-            sdkVersion: release["sdk"]["version"],
+            sdkVersion: foundSdk["version"],
             security: release["security"],
             securityIssues: []
         };
@@ -289,7 +310,7 @@ class NullWritable extends stream_1.Writable {
 
 /***/ }),
 
-/***/ 3401:
+/***/ 2689:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -317,10 +338,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = void 0;
-const core = __importStar(__webpack_require__(8298));
+const core = __importStar(__webpack_require__(2507));
 const fs = __importStar(__webpack_require__(5747));
 const path = __importStar(__webpack_require__(5622));
-const DotNetSdkUpdater_1 = __webpack_require__(5868);
+const DotNetSdkUpdater_1 = __webpack_require__(424);
 async function run() {
     var _a;
     try {
@@ -365,7 +386,7 @@ if (require.main === require.cache[eval('__filename')]) {
 
 /***/ }),
 
-/***/ 6544:
+/***/ 3852:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -379,7 +400,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const os = __importStar(__webpack_require__(2087));
-const utils_1 = __webpack_require__(2985);
+const utils_1 = __webpack_require__(1111);
 /**
  * Commands
  *
@@ -451,7 +472,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 8298:
+/***/ 2507:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -473,9 +494,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __webpack_require__(6544);
-const file_command_1 = __webpack_require__(7707);
-const utils_1 = __webpack_require__(2985);
+const command_1 = __webpack_require__(3852);
+const file_command_1 = __webpack_require__(7542);
+const utils_1 = __webpack_require__(1111);
 const os = __importStar(__webpack_require__(2087));
 const path = __importStar(__webpack_require__(5622));
 /**
@@ -696,7 +717,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 7707:
+/***/ 7542:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -714,7 +735,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__webpack_require__(5747));
 const os = __importStar(__webpack_require__(2087));
-const utils_1 = __webpack_require__(2985);
+const utils_1 = __webpack_require__(1111);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -732,7 +753,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 2985:
+/***/ 1111:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -758,7 +779,7 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 5245:
+/***/ 6995:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -780,7 +801,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tr = __importStar(__webpack_require__(9624));
+const tr = __importStar(__webpack_require__(2796));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -809,7 +830,7 @@ exports.exec = exec;
 
 /***/ }),
 
-/***/ 9624:
+/***/ 2796:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -835,8 +856,8 @@ const os = __importStar(__webpack_require__(2087));
 const events = __importStar(__webpack_require__(8614));
 const child = __importStar(__webpack_require__(3129));
 const path = __importStar(__webpack_require__(5622));
-const io = __importStar(__webpack_require__(1171));
-const ioUtil = __importStar(__webpack_require__(6706));
+const io = __importStar(__webpack_require__(8748));
+const ioUtil = __importStar(__webpack_require__(5163));
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -1416,7 +1437,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 5523:
+/***/ 2595:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -1473,7 +1494,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 7534:
+/***/ 2621:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -1499,8 +1520,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokit = exports.context = void 0;
-const Context = __importStar(__webpack_require__(5523));
-const utils_1 = __webpack_require__(7676);
+const Context = __importStar(__webpack_require__(2595));
+const utils_1 = __webpack_require__(4662);
 exports.context = new Context.Context();
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
@@ -1516,7 +1537,7 @@ exports.getOctokit = getOctokit;
 
 /***/ }),
 
-/***/ 9080:
+/***/ 3355:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -1542,7 +1563,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
-const httpClient = __importStar(__webpack_require__(544));
+const httpClient = __importStar(__webpack_require__(1404));
 function getAuthString(token, options) {
     if (!token && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -1566,7 +1587,7 @@ exports.getApiBaseUrl = getApiBaseUrl;
 
 /***/ }),
 
-/***/ 7676:
+/***/ 4662:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -1592,12 +1613,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
-const Context = __importStar(__webpack_require__(5523));
-const Utils = __importStar(__webpack_require__(9080));
+const Context = __importStar(__webpack_require__(2595));
+const Utils = __importStar(__webpack_require__(3355));
 // octokit + plugins
-const core_1 = __webpack_require__(1514);
-const plugin_rest_endpoint_methods_1 = __webpack_require__(7780);
-const plugin_paginate_rest_1 = __webpack_require__(1139);
+const core_1 = __webpack_require__(359);
+const plugin_rest_endpoint_methods_1 = __webpack_require__(985);
+const plugin_paginate_rest_1 = __webpack_require__(2900);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
 const defaults = {
@@ -1627,7 +1648,7 @@ exports.getOctokitOptions = getOctokitOptions;
 
 /***/ }),
 
-/***/ 544:
+/***/ 1404:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -1635,7 +1656,7 @@ exports.getOctokitOptions = getOctokitOptions;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const http = __webpack_require__(8605);
 const https = __webpack_require__(7211);
-const pm = __webpack_require__(5804);
+const pm = __webpack_require__(5055);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -2054,7 +2075,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __webpack_require__(271);
+                tunnel = __webpack_require__(8409);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -2170,7 +2191,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 5804:
+/***/ 5055:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2235,7 +2256,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 6706:
+/***/ 5163:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -2437,7 +2458,7 @@ function isUnixExecutable(stats) {
 
 /***/ }),
 
-/***/ 1171:
+/***/ 8748:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -2455,7 +2476,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const childProcess = __webpack_require__(3129);
 const path = __webpack_require__(5622);
 const util_1 = __webpack_require__(1669);
-const ioUtil = __webpack_require__(6706);
+const ioUtil = __webpack_require__(5163);
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2734,7 +2755,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 6782:
+/***/ 792:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2791,7 +2812,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 1514:
+/***/ 359:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -2799,11 +2820,11 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var universalUserAgent = __webpack_require__(7403);
-var beforeAfterHook = __webpack_require__(5563);
-var request = __webpack_require__(2764);
-var graphql = __webpack_require__(9078);
-var authToken = __webpack_require__(6782);
+var universalUserAgent = __webpack_require__(6677);
+var beforeAfterHook = __webpack_require__(2167);
+var request = __webpack_require__(4013);
+var graphql = __webpack_require__(9444);
+var authToken = __webpack_require__(792);
 
 function _objectWithoutPropertiesLoose(source, excluded) {
   if (source == null) return {};
@@ -2973,7 +2994,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 3389:
+/***/ 2929:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -2981,8 +3002,8 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __webpack_require__(8374);
-var universalUserAgent = __webpack_require__(7403);
+var isPlainObject = __webpack_require__(9907);
+var universalUserAgent = __webpack_require__(6677);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -3371,7 +3392,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 9078:
+/***/ 9444:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -3379,8 +3400,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __webpack_require__(2764);
-var universalUserAgent = __webpack_require__(7403);
+var request = __webpack_require__(4013);
+var universalUserAgent = __webpack_require__(6677);
 
 const VERSION = "4.5.7";
 
@@ -3487,7 +3508,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 1139:
+/***/ 2900:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3627,7 +3648,7 @@ exports.paginateRest = paginateRest;
 
 /***/ }),
 
-/***/ 7780:
+/***/ 985:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4789,7 +4810,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 320:
+/***/ 9026:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -4799,8 +4820,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __webpack_require__(5543);
-var once = _interopDefault(__webpack_require__(5001));
+var deprecation = __webpack_require__(2581);
+var once = _interopDefault(__webpack_require__(2042));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -4852,7 +4873,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 2764:
+/***/ 4013:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -4862,11 +4883,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __webpack_require__(3389);
-var universalUserAgent = __webpack_require__(7403);
-var isPlainObject = __webpack_require__(8374);
-var nodeFetch = _interopDefault(__webpack_require__(7545));
-var requestError = __webpack_require__(320);
+var endpoint = __webpack_require__(2929);
+var universalUserAgent = __webpack_require__(6677);
+var isPlainObject = __webpack_require__(9907);
+var nodeFetch = _interopDefault(__webpack_require__(7315));
+var requestError = __webpack_require__(9026);
 
 const VERSION = "5.4.10";
 
@@ -5008,12 +5029,12 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 5563:
+/***/ 2167:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-var register = __webpack_require__(2858)
-var addHook = __webpack_require__(3728)
-var removeHook = __webpack_require__(9960)
+var register = __webpack_require__(2062)
+var addHook = __webpack_require__(1357)
+var removeHook = __webpack_require__(287)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -5072,7 +5093,7 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 
-/***/ 3728:
+/***/ 1357:
 /***/ ((module) => {
 
 module.exports = addHook
@@ -5125,7 +5146,7 @@ function addHook (state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 2858:
+/***/ 2062:
 /***/ ((module) => {
 
 module.exports = register
@@ -5160,7 +5181,7 @@ function register (state, name, method, options) {
 
 /***/ }),
 
-/***/ 9960:
+/***/ 287:
 /***/ ((module) => {
 
 module.exports = removeHook
@@ -5184,7 +5205,7 @@ function removeHook (state, name, method) {
 
 /***/ }),
 
-/***/ 5543:
+/***/ 2581:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5212,7 +5233,7 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 8374:
+/***/ 9907:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5258,7 +5279,7 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 7545:
+/***/ 7315:
 /***/ ((module, exports, __webpack_require__) => {
 
 "use strict";
@@ -5423,7 +5444,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = __webpack_require__(7220).convert;
+	convert = __webpack_require__(1963).convert;
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -6915,10 +6936,10 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 5001:
+/***/ 2042:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-var wrappy = __webpack_require__(2736)
+var wrappy = __webpack_require__(9047)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -6964,15 +6985,15 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 271:
+/***/ 8409:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-module.exports = __webpack_require__(2551);
+module.exports = __webpack_require__(2668);
 
 
 /***/ }),
 
-/***/ 2551:
+/***/ 2668:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -7244,7 +7265,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 7403:
+/***/ 6677:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7270,7 +7291,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 2736:
+/***/ 9047:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -7310,7 +7331,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 7220:
+/***/ 1963:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -7468,6 +7489,6 @@ module.exports = require("zlib");;
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(3401);
+/******/ 	return __webpack_require__(2689);
 /******/ })()
 ;

--- a/dist/index.js
+++ b/dist/index.js
@@ -106,8 +106,12 @@ class DotNetSdkUpdater {
             body += `which also updates the .NET runtime from version [\`\`${versions.current.runtimeVersion}\`\`](${versions.current.releaseNotes}) to version [\`\`${versions.latest.runtimeVersion}\`\`](${versions.latest.releaseNotes}).`;
         }
         if (versions.latest.security && versions.latest.securityIssues.length > 0) {
+            let issues = versions.latest.securityIssues;
+            if (versions.current.security && versions.current.securityIssues.length > 0) {
+                issues = issues.filter(issue => versions.current.securityIssues.findIndex(other => other.id === issue.id) < 0);
+            }
             body += `\n\nThis release includes fixes for the following security issue(s):`;
-            versions.latest.securityIssues.forEach(issue => {
+            issues.forEach(issue => {
                 body += `\n  * [${issue.id}](${issue.url})`;
             });
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-dotnet-sdk",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "private": true,
   "description": "A GitHub Action that updates the .NET SDK.",
   "main": "lib/update-dotnet-sdk.js",

--- a/src/DotNetSdkUpdater.ts
+++ b/src/DotNetSdkUpdater.ts
@@ -115,8 +115,14 @@ export class DotNetSdkUpdater {
 
     if (versions.latest.security && versions.latest.securityIssues.length > 0) {
 
+      let issues: CveInfo[] = versions.latest.securityIssues;
+
+      if (versions.current.security && versions.current.securityIssues.length > 0) {
+        issues = issues.filter(issue => versions.current.securityIssues.findIndex(other => other.id === issue.id) < 0);
+      }
+
       body += `\n\nThis release includes fixes for the following security issue(s):`;
-      versions.latest.securityIssues.forEach(issue => {
+      issues.forEach(issue => {
         body += `\n  * [${issue.id}](${issue.url})`;
       });
     }

--- a/src/DotNetSdkUpdater.ts
+++ b/src/DotNetSdkUpdater.ts
@@ -237,10 +237,37 @@ export class DotNetSdkUpdater {
   private static getReleaseForSdk(sdkVersion: string, releaseInfo: any): ReleaseInfo {
 
     let releases: any[] = releaseInfo["releases"];
+    let foundSdk: any = null;
 
-    const foundRelease = releases.filter((info: any) => {
-      return info["sdk"]["version"] === sdkVersion;
+    let foundRelease = releases.filter((info: any) => {
+      const sdk = info["sdk"];
+      if (sdk["version"] === sdkVersion) {
+        foundSdk = sdk;
+        return true;
+      }
+      return false;
     });
+
+
+
+    if (foundRelease.length < 1) {
+      foundRelease = releases.filter((info: any) => {
+
+        const sdks: any[] = info["sdks"];
+
+        if (sdks !== null) {
+          for (let i = 0; i < sdks.length; i++) {
+            const sdk = sdks[i];
+            if (sdk["version"] === sdkVersion) {
+              foundSdk = sdk;
+              return true;
+            }
+          }
+        }
+
+        return false;
+      })
+    }
 
     if (foundRelease.length < 1) {
       throw new Error(`Failed to find release for .NET SDK version ${sdkVersion}`);
@@ -251,7 +278,7 @@ export class DotNetSdkUpdater {
     const result = {
       releaseNotes: release["release-notes"],
       runtimeVersion: release["runtime"]["version"],
-      sdkVersion: release["sdk"]["version"],
+      sdkVersion: foundSdk["version"],
       security: release["security"],
       securityIssues: <CveInfo[]>[]
     };

--- a/tests/DotNetSdkUpdater.test.ts
+++ b/tests/DotNetSdkUpdater.test.ts
@@ -9,7 +9,7 @@ import * as updater from "../src/DotNetSdkUpdater";
 
 describe("DotNetSdkUpdater tests", () => {
 
-  it("Gets correct info if a newer SDK is available", async () => {
+  it("Gets correct info if a newer SDK is available for the same MSBuild version", async () => {
 
     const releaseInfo = JSON.parse(
       fs.readFileSync(path.join(process.cwd(), "tests", "releases-3.1.json"), { encoding: "utf8" })
@@ -32,6 +32,38 @@ describe("DotNetSdkUpdater tests", () => {
     expect(actual.latest.sdkVersion).toBe("3.1.404");
     expect(actual.latest.security).toBe(false);
     expect(actual.latest.securityIssues).not.toBeNull();
+
+  }, 10000);
+
+  it("Gets correct info if a newer SDK is available for a different MSBuild version", async () => {
+
+    const releaseInfo = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), "tests", "releases-5.0.json"), { encoding: "utf8" })
+    );
+
+    const actual = await updater.DotNetSdkUpdater.getLatestRelease("5.0.103", releaseInfo);
+
+    expect(actual).not.toBeNull();
+    expect(actual.current).not.toBeNull();
+    expect(actual.latest).not.toBeNull();
+
+    expect(actual.current.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.3/5.0.200-sdk.md");
+    expect(actual.current.runtimeVersion).toBe("5.0.3");
+    expect(actual.current.sdkVersion).toBe("5.0.103");
+    expect(actual.current.security).toBe(true);
+    expect(actual.current.securityIssues).not.toBeNull();
+    expect(actual.current.securityIssues.length).toBe(2);
+    expect(actual.current.securityIssues[0].id).toBe("CVE-2021-1721");
+    expect(actual.current.securityIssues[1].id).toBe("CVE-2021-24112");
+
+    expect(actual.latest.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.3/5.0.200-sdk.md");
+    expect(actual.latest.runtimeVersion).toBe("5.0.3");
+    expect(actual.latest.sdkVersion).toBe("5.0.200");
+    expect(actual.latest.security).toBe(true);
+    expect(actual.latest.securityIssues.length).toBe(2);
+    expect(actual.latest.securityIssues).not.toBeNull();
+    expect(actual.latest.securityIssues[0].id).toBe("CVE-2021-1721");
+    expect(actual.latest.securityIssues[1].id).toBe("CVE-2021-24112");
 
   }, 10000);
 

--- a/tests/releases-5.0.json
+++ b/tests/releases-5.0.json
@@ -1,0 +1,5443 @@
+{
+  "channel-version": "5.0",
+  "latest-release": "5.0.3",
+  "latest-release-date": "2021-03-02",
+  "latest-runtime": "5.0.3",
+  "latest-sdk": "5.0.200",
+  "support-phase": "current",
+  "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
+  "releases": [
+    {
+      "release-date": "2021-03-02",
+      "release-version": "5.0.3",
+      "security": true,
+      "cve-list": [
+        {
+          "cve-id": "CVE-2021-1721",
+          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-1721"
+        },
+        {
+          "cve-id": "CVE-2021-24112",
+          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24112"
+        }
+      ],
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.3/5.0.200-sdk.md",
+      "runtime": {
+        "version": "5.0.3",
+        "version-display": "5.0.3",
+        "vs-version": "16.8.5",
+        "vs-mac-version": "8.8.8",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94f3d0cd-6ccc-4eac-bac5-7fd1396581d5/b51a89d445f3fb7b2a795f0119fc0575/dotnet-runtime-5.0.3-linux-arm.tar.gz",
+            "hash": "d89c1769dfdfe30092825a94aa0037ca99ef83a0935ba24755377813db9e4a2e49e41611d02cf24aa4a423fb44bc566cdd935f62db61fe04a5257932bed4abf4"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bbcf8972-286c-42f5-b7be-6bd61dc1b833/37bbc22e83223bf280883f0f6cce28d2/dotnet-runtime-5.0.3-linux-arm64.tar.gz",
+            "hash": "f4d176b48714121040470a25f76a1b3554edb358953c1bfb39bd111cf0dcc85cb8a5ebcd617efd207b3cfaef0a2d242f94e9f018a186828a750c5c0dc9bd7da5"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/433d8892-ef38-4838-b459-d0bbe4a66008/fda4b9e95c721dac8f01d25f1a39288d/dotnet-runtime-5.0.3-linux-musl-arm64.tar.gz",
+            "hash": "caccb6854393ca922aec23c10e3451787b445a2dac1e9bd8be2d33f70258e247ac9f97860570c8fc6438a17d938a7a8c026dffeecc914f3afe1981a198432b03"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/65045602-b193-496e-b403-bc5fcb5b1091/fd1657171b1f765118203bfc956c97df/dotnet-runtime-5.0.3-linux-musl-x64.tar.gz",
+            "hash": "85e4063792fb9d921a24f9da221a2b69c1faa253adb10644cc5907c35af92b3204f461fd6a9ec936ae37cfada47937f1c2b67174eabc778bd7305d66dc67e340"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/49cc8956-3b51-42ff-a718-0fe6326e2fe5/9c3b23c1b92f0b3a8f9d6c2e3e72095e/dotnet-runtime-5.0.3-linux-x64.tar.gz",
+            "hash": "263dbe260123c3d6d706ed8b5f4d510d9384216422e9af0d293df87ed98e84e1e0ffbf0c7dd543c40c5ccc95bd7cd006c8bbbe9f1cd1f060b1eaa2f7a60fea74"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/60a8becd-ff61-4e17-8329-4d85f9d1e3b9/06ef79dad25a85905afbb3965f613bad/dotnet-runtime-5.0.3-osx-x64.pkg",
+            "hash": "4eb508f76a599b5b1a51482657cd4c42446a9e6f7f32b2441127182981e2682e6e13d47bd895a7ae34b7b1b7ee5aabcf28b4e7c817ba5606b3104758945780a9"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ffc7b0f3-0d18-4b07-b242-4113c48a4067/fbce30bc00e359039ce115300609c16f/dotnet-runtime-5.0.3-osx-x64.tar.gz",
+            "hash": "a29bc8ddcb15b4be141495cd937b75cb2c1d83cd3d65900f0a591997a834f2187ffd3c56d44e2b3017ef0d70e032468a6630b2e16527aa8913d1a9b88dbe4da7"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b63525df-7379-4b27-b8eb-e21e3fbdfc41/646d6d51303ef5cb48ff6000cbb8e887/dotnet-runtime-5.0.3-win-arm64.exe",
+            "hash": "0e95d7d7730b106a631a60c0195214f5f33978e9aff98712a6cd91c7c21b7fe8e97f620a9f27b41d0a521027fb92a19495a4062c0689d5dc6402e18e32d422c0"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d9c565e7-9071-47ce-929f-8154b5bef409/85afd2f197748d789cdb62d70ad1de13/dotnet-runtime-5.0.3-win-arm64.zip",
+            "hash": "a8abc0250271acef6872f577844787d297310899f206f96d458848da1b22183fdcbdc8ff6af5f9bc63a41bbebfa724a16c23ceeb117ffac8fd866f15c59e0f25"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f05c10fe-fed3-43b6-b676-ff75021c2d9f/15cab750af61a29d70ef33c265354cf2/dotnet-runtime-5.0.3-win-x64.exe",
+            "hash": "ae69e34d0139b9d9232bde5ee9ec8e0f98d997344a9903b11f10dfa3bc07e965ef15f27f8b08befcfb07188f3dc6dfe1c638ef35dbd953fdcd0f548ef489a541"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/23185b06-bc63-402c-b94e-3bdfa999022b/c802fbf2c5a7511c13b764fcb295dba9/dotnet-runtime-5.0.3-win-x64.zip",
+            "hash": "1b29d6f51c11c2eb3101eb1cfd259deade6a4575e555e5a93839c37a9a14d7f81e7bb57d3e78d8957d7537d95a5db6577320d8e5e44d3bc70f33769f4fdd0aa9"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/58ebd1e5-efc7-4b89-b214-3dffb67f3148/1f7942a026bbd4d8a235a597ab83df9f/dotnet-runtime-5.0.3-win-x86.exe",
+            "hash": "159928dfa5204f7de9f118ea9781aaaac44ef2eae446d8dfe7d817692ad21bf4a550f1de7f423180d920aa9bf9827519c15c3b97071b2215b9493931b84adc53"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/18026047-c90d-49a3-a4b4-04424eaa65a2/3f6336a041ea19cdd2233d606a613b8d/dotnet-runtime-5.0.3-win-x86.zip",
+            "hash": "942088b89ef822a00c902433623144d460d8ae2e9d9973d4ca50fc8ce9db86b580dab14bf2267a2afb46cae98e39ab3b97d0ea7cf64edd9955a224126f44d39c"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.200",
+        "version-display": "5.0.200",
+        "runtime-version": "5.0.3",
+        "vs-version": "16.9",
+        "vs-mac-version": "8.9",
+        "vs-support": "Visual Studio 2019 (v16.9)",
+        "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+        "csharp-version": "9.0",
+        "fsharp-version": "5.0",
+        "vb-version": "16.0",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8f09af48-e88e-4b91-bae1-08a5c9183559/e10eefacab56a4f4c1165d4e26a5f0f9/dotnet-sdk-5.0.200-linux-arm.tar.gz",
+            "hash": "01544d37e118dbe2bb38c00947b11c64756bd69809c7b2a0c615df6d7d31d432b792c84d39709fb364f73c51a16349829e7331ccfb9307e569c39150e0b802c9"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0a823585-f6ac-4b4f-994d-c073d16267c3/af8c9fcdf76492048b60abfe0b311e2e/dotnet-sdk-5.0.200-linux-arm64.tar.gz",
+            "hash": "684b2f3bc59f090c5be14b993480c2600d7ac6703fb6af098f371f6404df7298e0be283ceef5cb28383ba334e3828bb92825269bf3a6ad4b8b37c2e0b15be3bf"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/38d6d87b-191c-4ccb-a525-0a0e09bbe6ef/fca4b23f8bb29555cbda08e77960e46e/dotnet-sdk-5.0.200-linux-musl-x64.tar.gz",
+            "hash": "2e73e524b1d61b9d69a1eb508e239e91aef8245b7947fdb9699ca32660674420239d6bd3d6c43dd8cad406afccda9bade01a8655170f046538aab45751dcfee0"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/64a6b4b9-a92e-4efc-a588-569d138919c6/a97f4be78d7cc237a4f5c306866f7a1c/dotnet-sdk-5.0.200-linux-x64.tar.gz",
+            "hash": "0d185e30fc2e81e5db452995e826b108f2bc90f7277a9dedc9a7539d9a9554d6f7e6a1e7b2527012c804d686acda6e6b4be1a0210c4d150486c07863b3b27f1e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a06c387d-2811-4fba-8b5f-86cb9f0bdeba/f41d1c63c5b6bcee9293484e845bc518/dotnet-sdk-5.0.200-osx-x64.pkg",
+            "hash": "ea5ecb4687985cb05e1da5b2fa09e17e944b0d2e323ef547fb6dfad6dbbef0e6ecd48eb98bd2327d9c6afa6ac20a5b0b5be84e1177cb5941f4d2a22cec2d156f"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db160ec7-2f36-4f41-9a87-fab65cd142f9/7d4afadf1808146ba7794edaf0f97924/dotnet-sdk-5.0.200-osx-x64.tar.gz",
+            "hash": "c655d35665698c6b1be9fcd5ebe9ee39f97f08552af8decf435dd7c31b273a4c8a1b90e6687c0add6c67148eba9650b2ef1c247a8bf04543cf12a153f4760fae"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/68607b2c-8324-4d85-ad01-c682c05bd41e/fee74f773c7dddcad14183bedc6359d0/dotnet-sdk-5.0.200-win-arm64.exe",
+            "hash": "a705ff3f7424c43c0d6067ee414854056588b542eeb66f448796398e59b2a72570d1bad57018721a494d7dda52f8c277b710c80a8c752b5a088a6390070862c6"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cea733ce-6339-4af3-bf9c-24c66b0ccf45/036ccf803130a6f24d688a63d9e9c156/dotnet-sdk-5.0.200-win-arm64.zip",
+            "hash": "4b72b107c45ee79392c8531526989363af39736b50d4b9c378c66c8686fdc91ac236cdfbc08788493e415ad03411a1e6b3ea903ff996a7f1a0bf3c34daea4927"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a105fe06-20a0-4233-8ff1-b85523b40f1d/5f26654016c41ab2dc6d8bc850a9bf4c/dotnet-sdk-5.0.200-win-x64.exe",
+            "hash": "ad82e39229f7c1b59578e86b29318a82bfff96831e7d845fb3044e9eed9c40d2963d1ccb8c23d02ace1be9f1591909a366dec9230332c6328875ab5dcc00f53c"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/761159fa-2843-4abe-8052-147e6c873a78/77658948a9e0f7bc31e978b6bc271ec8/dotnet-sdk-5.0.200-win-x64.zip",
+            "hash": "bed2ad5eb95f737687880c0d3903c1474f91c236faafbd541850bd3e0242b48ac213cf94fc9b911e62c40871861678d3cd589a3805890acf4b0f04d111723dda"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a9111d43-d9af-4aae-bf81-8a335fd7f490/5041619a227cb1fe473f3738b6b2e8fe/dotnet-sdk-5.0.200-win-x86.exe",
+            "hash": "773a81dabff01369b208d3234f526bddb8837b2307cb4d65cdad6e8b708655f6dbeb8e71001967d72270434fb36d74621d2ebe2cb85fb70182f60935db46a46f"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d7b29655-c546-4771-8a76-e38fbc68ac9a/f6704071f4947082c2f9db0539bcad16/dotnet-sdk-5.0.200-win-x86.zip",
+            "hash": "d52ec04a46f9349df254470bbd247323d0d723ed7f4cc90291acd816fa0412c4e39f071a3a6bd347c51d0f93692cfc15b740402326789c2c562f9ec56944ee0b"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.200",
+          "version-display": "5.0.200",
+          "runtime-version": "5.0.3",
+          "vs-version": "16.9",
+          "vs-mac-version": "8.9",
+          "vs-support": "Visual Studio 2019 (v16.9)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+          "csharp-version": "9.0",
+          "fsharp-version": "5.0",
+          "vb-version": "16.0",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/8f09af48-e88e-4b91-bae1-08a5c9183559/e10eefacab56a4f4c1165d4e26a5f0f9/dotnet-sdk-5.0.200-linux-arm.tar.gz",
+              "hash": "01544d37e118dbe2bb38c00947b11c64756bd69809c7b2a0c615df6d7d31d432b792c84d39709fb364f73c51a16349829e7331ccfb9307e569c39150e0b802c9"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0a823585-f6ac-4b4f-994d-c073d16267c3/af8c9fcdf76492048b60abfe0b311e2e/dotnet-sdk-5.0.200-linux-arm64.tar.gz",
+              "hash": "684b2f3bc59f090c5be14b993480c2600d7ac6703fb6af098f371f6404df7298e0be283ceef5cb28383ba334e3828bb92825269bf3a6ad4b8b37c2e0b15be3bf"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/38d6d87b-191c-4ccb-a525-0a0e09bbe6ef/fca4b23f8bb29555cbda08e77960e46e/dotnet-sdk-5.0.200-linux-musl-x64.tar.gz",
+              "hash": "2e73e524b1d61b9d69a1eb508e239e91aef8245b7947fdb9699ca32660674420239d6bd3d6c43dd8cad406afccda9bade01a8655170f046538aab45751dcfee0"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/64a6b4b9-a92e-4efc-a588-569d138919c6/a97f4be78d7cc237a4f5c306866f7a1c/dotnet-sdk-5.0.200-linux-x64.tar.gz",
+              "hash": "0d185e30fc2e81e5db452995e826b108f2bc90f7277a9dedc9a7539d9a9554d6f7e6a1e7b2527012c804d686acda6e6b4be1a0210c4d150486c07863b3b27f1e"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a06c387d-2811-4fba-8b5f-86cb9f0bdeba/f41d1c63c5b6bcee9293484e845bc518/dotnet-sdk-5.0.200-osx-x64.pkg",
+              "hash": "ea5ecb4687985cb05e1da5b2fa09e17e944b0d2e323ef547fb6dfad6dbbef0e6ecd48eb98bd2327d9c6afa6ac20a5b0b5be84e1177cb5941f4d2a22cec2d156f"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/db160ec7-2f36-4f41-9a87-fab65cd142f9/7d4afadf1808146ba7794edaf0f97924/dotnet-sdk-5.0.200-osx-x64.tar.gz",
+              "hash": "c655d35665698c6b1be9fcd5ebe9ee39f97f08552af8decf435dd7c31b273a4c8a1b90e6687c0add6c67148eba9650b2ef1c247a8bf04543cf12a153f4760fae"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.exe",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/68607b2c-8324-4d85-ad01-c682c05bd41e/fee74f773c7dddcad14183bedc6359d0/dotnet-sdk-5.0.200-win-arm64.exe",
+              "hash": "a705ff3f7424c43c0d6067ee414854056588b542eeb66f448796398e59b2a72570d1bad57018721a494d7dda52f8c277b710c80a8c752b5a088a6390070862c6"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/cea733ce-6339-4af3-bf9c-24c66b0ccf45/036ccf803130a6f24d688a63d9e9c156/dotnet-sdk-5.0.200-win-arm64.zip",
+              "hash": "4b72b107c45ee79392c8531526989363af39736b50d4b9c378c66c8686fdc91ac236cdfbc08788493e415ad03411a1e6b3ea903ff996a7f1a0bf3c34daea4927"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a105fe06-20a0-4233-8ff1-b85523b40f1d/5f26654016c41ab2dc6d8bc850a9bf4c/dotnet-sdk-5.0.200-win-x64.exe",
+              "hash": "ad82e39229f7c1b59578e86b29318a82bfff96831e7d845fb3044e9eed9c40d2963d1ccb8c23d02ace1be9f1591909a366dec9230332c6328875ab5dcc00f53c"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/761159fa-2843-4abe-8052-147e6c873a78/77658948a9e0f7bc31e978b6bc271ec8/dotnet-sdk-5.0.200-win-x64.zip",
+              "hash": "bed2ad5eb95f737687880c0d3903c1474f91c236faafbd541850bd3e0242b48ac213cf94fc9b911e62c40871861678d3cd589a3805890acf4b0f04d111723dda"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a9111d43-d9af-4aae-bf81-8a335fd7f490/5041619a227cb1fe473f3738b6b2e8fe/dotnet-sdk-5.0.200-win-x86.exe",
+              "hash": "773a81dabff01369b208d3234f526bddb8837b2307cb4d65cdad6e8b708655f6dbeb8e71001967d72270434fb36d74621d2ebe2cb85fb70182f60935db46a46f"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d7b29655-c546-4771-8a76-e38fbc68ac9a/f6704071f4947082c2f9db0539bcad16/dotnet-sdk-5.0.200-win-x86.zip",
+              "hash": "d52ec04a46f9349df254470bbd247323d0d723ed7f4cc90291acd816fa0412c4e39f071a3a6bd347c51d0f93692cfc15b740402326789c2c562f9ec56944ee0b"
+            }
+          ]
+        },
+        {
+          "version": "5.0.103",
+          "version-display": "5.0.103",
+          "runtime-version": "5.0.3",
+          "vs-version": "16.8.5",
+          "vs-mac-version": "8.8",
+          "vs-support": "Visual Studio 2019 (v16.8)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+          "csharp-version": "9.0",
+          "fsharp-version": "5.0",
+          "vb-version": "16.0",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/cd11b0d1-8d79-493f-a702-3ecbadb040aa/d24855458a90944d251dd4c68041d0b7/dotnet-sdk-5.0.103-linux-arm.tar.gz",
+              "hash": "ad07c5921b79d3ea3fdd7af2d26f118dcf74aa8ab6e147e0cdfeef94e656606777df8832135d52d24f22b5f1ebe75f51ee78462aeaa262b675e89ad04d55c0bf"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5c2e5668-d7f9-4705-acb0-04ceeda6dadf/4eca3d1ffd92cb2b5f9152155a5529b4/dotnet-sdk-5.0.103-linux-arm64.tar.gz",
+              "hash": "179bcc4d280011a0d23f8f0d78349a372fe495e9c5aff106882c08025367ce49afe897f65c033c3f046bae2b1e49f7f6526edce273ab21e77812bbb8317d08a8"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d02ece12-7202-4a7b-93f7-661268d8b315/d62d32d57d330943b8a889cbd9cd58df/dotnet-sdk-5.0.103-linux-musl-x64.tar.gz",
+              "hash": "0bb6fc1aa4b8486b437f28baeda3b810f7c38ef195761a5eb4c5236975efc505dbff7abbdf7549a34278d110c8a7cf283e52f033a404b300e0f96a8ae0fca4a8"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a2052604-de46-4cd4-8256-9bc222537d32/a798771950904eaf91c0c37c58f516e1/dotnet-sdk-5.0.103-linux-x64.tar.gz",
+              "hash": "bf452dbdaec7a82835cfc7c698d2558e7ac4b092e7ef35092796ba5440eb45dd880e86c1e61f8e170ac4eb813240cf83f9fc2e342dfa8b37e45afdf5cd82fb8e"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/43e9caf4-2087-4bc6-8031-5efba1268703/a6b0491578d385a9780603ea51df8de9/dotnet-sdk-5.0.103-osx-x64.pkg",
+              "hash": "2348924b85e63887ecebb0f3b430db69163e180f8919fd21b2833b7af9f27222e8733ee989de180da8a54ff3c6d7735c36b514deeb517f0b1112e7e266b36920"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3de2d949-fcb5-4586-a217-2c33854d295f/943f0d92252338e11fd11b002a3a3861/dotnet-sdk-5.0.103-osx-x64.tar.gz",
+              "hash": "fa0a5dac50e49bcf67e96f77ff9074204aa34b0e09c49c08cd9abaaced24f60d878f5fe782c5f01c6b0679e93f3f360aee7cc4687fcf89e92034db7ae38cf6d8"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.exe",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0aa88e72-364e-45d3-ac39-7dd10f0f2f26/461a398a0ab4e1fca8fac573a7b31a4b/dotnet-sdk-5.0.103-win-arm64.exe",
+              "hash": "ac40904adc990708c7e2e6771bab879d05557307e17ffd76ab828ef73b2ecb51948ccd66697bcbc16997071f53a1f311fd1e62a2b4c1b85300e527568b739746"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3fd92d44-eace-490d-aa9d-f7aef699162e/501e8fdd1438b3795afc55ab72397143/dotnet-sdk-5.0.103-win-arm64.zip",
+              "hash": "79a057a90880b3dd9a0c5852585fc532cf53322cf487286f6e845383a187e1967119bfd17bf176a2024d39cc24d925cd719cad4814ac846f9a83b1d13ae9ff2a"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/674a9f7d-862e-4f92-91b6-f1cf3fed03ce/e07db4de77ada8da2c23261dfe9db138/dotnet-sdk-5.0.103-win-x64.exe",
+              "hash": "8c944c7ee2e33e5bfbf0d95d0b26a5365d42a73f4a95d0b7bed3c24aca0b61cf89cc8539d3452204b82e1ab737a85aa404a9a254d6dab742918d97562006c8c5"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/178989cb-2bd9-4da8-881f-1acde0d4386c/5cdcc54c9d8f004ab748397a685d5d1b/dotnet-sdk-5.0.103-win-x64.zip",
+              "hash": "7ff6316b2bf5219a794d86c716fefe6b80b0c8095f0ed98390f628f4cbd8c573c1a21369ac9aa9596826825ea595afccc14e207489c7346f074cfacf1be94d58"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/34abccd8-cff2-4c15-ad61-f16c6469ee53/d38befd0e6538d89e6f997418b4b0b8c/dotnet-sdk-5.0.103-win-x86.exe",
+              "hash": "c55b0427d96b53fb5bf8e47833d486c2a8802123906bf3d92b2688e4cbcd77f6cb02fc61534e2054b78c7c5d5fe50d4e946700feaedd2f90bf7b93f85169aba5"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5696bb86-54a9-4d91-b34d-5ff4cf2daac4/c868e23c87303018994c934b2758ab06/dotnet-sdk-5.0.103-win-x86.zip",
+              "hash": "08675887ed2ed6016be2581a94967316b4af5ea5a9d43d6ec1541a7925f2eba875804860a28f0e491fb17560d1fac197d8230b43f4e2fa95a98d0eaae6ef46e2"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.3",
+        "version-display": "5.0.3",
+        "version-aspnetcoremodule": [
+          "15.0.21023.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6d8c577b-d6a2-4110-a105-58f578f136db/236c018b3ee005d47fdcb5e9960eaf1f/aspnetcore-runtime-5.0.3-linux-arm.tar.gz",
+            "hash": "2e9ea5fdb15b8fe56890cfb635216b3c68afb12a48d40e2c1e58838baffb1a80aa75e6da363d878c3caaf9880c506ec12e316b93baae1e307ef04eb90d7d327c"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dcdcf093-9cc1-4591-9a1d-7c1f06c7e462/c34d67bdc70d5f92be1bbbb023220b7c/aspnetcore-runtime-5.0.3-linux-arm64.tar.gz",
+            "hash": "4eaf1b0120479102b342f1f3a8ad8f40b7326e3657d2b7359c09fd1951c5169ca02d1ead4d4d01f6e594adbe0cb21f135f4c61ff90613219596f6cc222161717"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/baae48ad-7e78-432f-ab7a-3769adf877b9/3f54ab3d55cfc58a8b6738d7abfe1775/aspnetcore-runtime-5.0.3-linux-musl-arm64.tar.gz",
+            "hash": "adfd3548e9b8bc826a5746edc9501a504912a08e5b397a71b940847ff1f86edf85b747ce261a80dffa95b7cd7265f3d7552921e7216f224f4cb409b45e207d64"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8af40459-43ae-465b-b40e-e2cf1f7f8832/8c083a48764ae6fa4de1a288b5e1f903/aspnetcore-runtime-5.0.3-linux-musl-x64.tar.gz",
+            "hash": "cd4471a542b4883987c067ecf180bd1ccc414f54fc90dd134c59bdba58f8e102366494b4fffb242de57c248d3915f34953de5330a9664b318ae58c1e1c004905"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/86b1cadb-8736-40c5-aaf8-654da39394fc/df326f9481f4da03c7e31263d42a3b1d/aspnetcore-runtime-5.0.3-linux-x64.tar.gz",
+            "hash": "188618b07cd5c97a34c77efccc7c4eba10a52681592ef711a005c82d243e601891418e0dcc27a22aae7dd6ae33d35e0bb7aa9b9fc022746c6c2414bd25cdb110"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dc06d9c6-e1fb-466f-aa4c-59998dbcd6f9/5636f8791058b3ad809179fc421dda6a/aspnetcore-runtime-5.0.3-osx-x64.tar.gz",
+            "hash": "924eaea6a5331835238afc84ba7dd9281aabb4c2fedf0f5383820aebdf13e916720c5889e058e6c1da0261a1f828fdb241fff7a076bef6bc2719f9dc3dc92ab1"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/26feb72c-062a-407b-9ed0-ef31cc4d6099/9b4b355e96d1550a424aa70e63676c5d/aspnetcore-runtime-5.0.3-win-arm64.zip",
+            "hash": "94ae7496317272cbd2f5a3e495e1b4c5e493a4c716fa82d8b19e78a1654510d1aa1bb5c5bed9f256e8064a1c5f37d02f15ce425fefc992c30c884d3465066621"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/414172c8-580b-45f4-b203-7c8cd4aed3c4/aae889e11dc2c76dc47ababde8649731/aspnetcore-runtime-5.0.3-win-x64.exe",
+            "hash": "69e8490ab8120ba4c076d4eea2e07e9660ebaef484ec5d7cab436e967574bb672bfd1e7571255b7ec8dda5be6540f530170688c5f68c3656ee45664f1085693c"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aafd17b7-5e78-4526-9ed5-a6388b421ed3/96a536e97bd15d1ed4ab7cfc0e4ca71a/aspnetcore-runtime-5.0.3-win-x64.zip",
+            "hash": "1188f9af667338bd1785246d1682876c10eabd584f1f8dc52a7cae06d2ad03c0b4236c4a603bd436d5fcf8f4221026b6a64cb4aa5ee13bf1f8e32e3b774e25d0"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0cd54ac9-9526-4892-a127-cab2c13c6a4b/50faf5c2cbd5f9f42c7c19b4f78bf2df/aspnetcore-runtime-5.0.3-win-x86.exe",
+            "hash": "b41d73e229b024eb89702fc8e11574ead23079b6443ee2a7e1050b982ede4c809e1e3e8f23f0a5bc9024fa07843ed74e2dca1ed29a92dfa794c415dc1b8cf9b8"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8ac1d8a1-73ac-48e1-b561-a93536a7c22e/d04f05e12d03e42086e6c5da9585a457/aspnetcore-runtime-5.0.3-win-x86.zip",
+            "hash": "60561070de7b4900099ab23f80b5ce18df6360ad1a3b09306b3fe8ed855d4c117284ba31abec0f10004300b4bed77ded6faf26797a2f418a8e22f37257206ffb"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dff39ddb-b399-43c5-9af0-04875134ce04/1c449bb9ad4cf75ec616482854751069/dotnet-hosting-5.0.3-win.exe",
+            "hash": "e4e20d60dedcfdab77b04b068b81d2d2f66a767f54db00fa71323850ed96e0ad6c141b6d83fea3dbbeee715c4ade2fb8b45b060cb42130c938e3e28e0a1971e8",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.3",
+        "version-display": "5.0.3",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c6541c87-42f2-4c5d-b6db-2df0dade5e00/13e89a5fec3ddb224cd93dd18b0761ff/windowsdesktop-runtime-5.0.3-win-x64.exe",
+            "hash": "216875b7be2bb1991015bd2ad390dda43263db51e173484dd9abaa38ef62c510e446d3135d6a4d84acae86ba2237ceca0645fb9fa2588edf2801c00ef4a13c1c"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a8dcbda1-8720-453c-9ec6-5a9d90935643/28754321a8b966f1ce837e6f59035b48/windowsdesktop-runtime-5.0.3-win-x86.exe",
+            "hash": "942f3348485fede89e339f4bc4f308fa9dcfaea92d54f805a420849ce37a0f4bcb812b56ecf04312c9dfa363f32ff637c07a72ccd9b8d0a6d131e69717a7e00d"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2021-01-12",
+      "release-version": "5.0.2",
+      "security": true,
+      "cve-list": [
+        {
+          "cve-id": "CVE-2021-1723",
+          "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-1723"
+        }
+      ],
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.2/5.0.2.md",
+      "runtime": {
+        "version": "5.0.2",
+        "version-display": "5.0.2",
+        "vs-version": "16.8.4",
+        "vs-mac-version": "8.8.5",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4e24057a-80d3-4de8-bbab-f337f8cdf56f/6c4775b4dee44be13355ca74b86797cf/dotnet-runtime-5.0.2-linux-arm.tar.gz",
+            "hash": "bfdfdd0dd176af6cdaa61c50b3fa8687031c6ff9e4dc67a6e02fbf24660ef456ad1946c00f9f013751ccc59f777b04ee535d8998996edc67101df17c3413fa77"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/da9f2fae-5a8b-40f4-b7e7-e4961f6e563c/f490ee2c3e2359eef0f9d3f5474a75c1/dotnet-runtime-5.0.2-linux-arm64.tar.gz",
+            "hash": "4328bee854cabda54e9a81c9351b8b86291357b6b1cb7802a1b3733238afca5a0910329d0ede4ba5755766601c32694580622eacde62cd18a64144cbe270ba8b"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2d48075f-8d7e-4f17-ae96-33902e5d7cd1/f3f5376248a049b8476d8a582fb93ff7/dotnet-runtime-5.0.2-linux-musl-arm64.tar.gz",
+            "hash": "d2b17c34cdffc70eca58bc139cdd38fd6ac998631f25cab145047e3509df5a9c0b8cc8a88fce32e5bf2982b6ef373a3d0ef3f41cbb88e270b9dce35aff7d67e7"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/47f4383b-2508-4556-aec9-ed98f9c31bbc/16bf1a085390e9a8a9ddba95cb31353c/dotnet-runtime-5.0.2-linux-musl-x64.tar.gz",
+            "hash": "84e69846188689cf5ee1eddce77c6cf92a7becddac9cdd9b985a490446d5acbd5d59e3703e8da4241895c1907b85bac852735c756098774e3b890c1944cda64f"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/824175f2-5577-46ec-a675-95d2f652575f/07dafc2398e669afa7d25f2d47398c36/dotnet-runtime-5.0.2-linux-x64.tar.gz",
+            "hash": "e3ce93a74e9c69098e6767ac1b36b53ce71da53bce68c9b84bcd767c2015cf4f818640cb5311c2cf3934e9f39e59562cc83a533956d114ad446420b7c26f53a7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b9f136a4-0898-4ad8-98b5-896629d24f14/ba28f0f0d1225b4dab1c38a737b9149c/dotnet-runtime-5.0.2-osx-x64.pkg",
+            "hash": "1c73d94d53fcd469c7179a77ecd6d8aa9121f7303115e838dea8a2594a105f01bada39a7f1530d92da0121538fbfe3f4a1f90a2b37e3d7200f6d8b5a4b9a0afb"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6136d22d-3fd7-4b43-a963-cec1a12e06da/a512860af0f18b7b3a6dabe6f5e55b3f/dotnet-runtime-5.0.2-osx-x64.tar.gz",
+            "hash": "08d77120b7eb9e8080d7ac11147d09fd725c022f49f297a01d17fb432fc104918811c9db6343fbfcda6894fab5a431dd54600b56e4bbb2aed2b0fe8a9592bfa0"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6768dc3b-0913-4526-8e86-6a63a40135b1/c4497bb6b72ccf139830075b862850af/dotnet-runtime-5.0.2-win-arm64.exe",
+            "hash": "59b915dee5f4865925598bdcebee3cee3117f7487908f933a1bd6447ea8fc9bb1e80b15c42908012e898f2500b340f7bafe0106a55d17f215da43e173b8ebbd3"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ac414c78-32bb-4fa7-b2a5-3ca19e577fff/e8c8c2391301b0cac9085422e0446b0b/dotnet-runtime-5.0.2-win-arm64.zip",
+            "hash": "d388f38c31fe35606bb5f6b2b1dd2d18d52ad64aef6cad493e1ba25a8b3b85a562dc55c748173ade0a836711562374c58be9fb0d172a56d6514057857311bac0"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8526b5e6-e6e7-4d0b-902b-1f4ad5dd1462/7de15b8c6ab0387402d5958e99a62ed9/dotnet-runtime-5.0.2-win-x64.exe",
+            "hash": "3baee14a3e2ecefea9dfd6de20c35886af8542b43f27fe83c74f24ed188810d50cb8d06b1991a092da923e565b3630534bb8423c92c0d580be0ab752c7703b51"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4f44c1f4-2860-4b92-9e32-2d93ce2b16aa/93d5ad650664aec50d05ae6c436913f0/dotnet-runtime-5.0.2-win-x64.zip",
+            "hash": "8b63aa1acbe0633aa50e491c52e7782d2f60ded441c99980a81f7479b57c10e660a9c2faadc4d860757f0ee55104688d4cd3c0f4f42e85d313fb1a64ae7a3cf3"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/46f8a025-ea67-4288-8e6a-709cfebc9b4b/69045dd85bcbfdd50441a87dedc13bd0/dotnet-runtime-5.0.2-win-x86.exe",
+            "hash": "9b7408bce5940b386b431ae8df5f49c8864e1435f61c603f838f55650d2d07592c9e4c9700420b3f1eed680c4ba02e10ac420d9ecf5f746214f10345b1502cf1"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa281535-ba5d-4fea-a0ec-f47eb90436b4/3b070e6dff1b235d2c9780c52cb36522/dotnet-runtime-5.0.2-win-x86.zip",
+            "hash": "0072f29192ad48d246ae187505b7413a61a61f3b0e69b8ca53ce0d37e88f58138bbdbadf4decb3ae20194aea6fd7d6003c7e09170f7f98e3c036e63cc07d2563"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.102",
+        "version-display": "5.0.102",
+        "runtime-version": "5.0.2",
+        "vs-version": "16.8.4",
+        "vs-mac-version": "8.8.5",
+        "vs-support": "Visual Studio 2019 (v16.8)",
+        "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+        "csharp-version": "9.0",
+        "fsharp-version": "5.0",
+        "vb-version": "15.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/726e260e-ce94-46c3-a169-57b2ebf5433d/5fb2a00b04b3509a0a6db63e302523a8/dotnet-sdk-5.0.102-linux-arm.tar.gz",
+            "hash": "23610a4193d8116109aaeebefa0bf023808f86d3e0a8ba52b89aa5b4b869385a5e57fc8458ff12f9ea8f359f6978498d47fd80d073ab79b2a7dfbc103b8ff903"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4fdd4708-8990-42db-998d-36ccfa593070/d67cb90c382e4eedbca8af1aebcbbe19/dotnet-sdk-5.0.102-linux-arm64.tar.gz",
+            "hash": "031272b86f435f88963b560c14342635d892345ac9a35d59ecaf6e425de8aab15ca5c3d0685c79027364e7a323927ba90568fe7ed8610f52ee5f961aef9fcf72"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf715f3d-ab8a-42a1-83ce-f6e1524a9f58/8d970618369fe8e6917a49c05aac58db/dotnet-sdk-5.0.102-linux-musl-x64.tar.gz",
+            "hash": "91ac9ea608b38402b2424d7754a823fade38261904a0fbb087f982b324aacf322c3500b520507f21b4aaac40eb059d8ef6d1656fd4f161d5afde2950210e86e8"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7f736160-9f34-4595-8d72-13630c437aef/b9c4513afb0f8872eb95793c70ac52f6/dotnet-sdk-5.0.102-linux-x64.tar.gz",
+            "hash": "0ce2d5365ca39808fb71baec4584d4ec786491c3735543dc93244604ea97e242377d0987cd8b1e529258dee68f203b5780559201e7ea6d84487d6d8d433329b3"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/52bd43f7-88c9-420c-80c0-f19bae344293/a8d56f01fdb6f71adb5e22c3ddd1c3c6/dotnet-sdk-5.0.102-osx-x64.pkg",
+            "hash": "c7b6d24e86484fb692397da946509245e4b959ea1aedd49c1de7275c89ea9b61af29c88f3e40885ddd27e427d965cdf06f808c988b08c426cd797fb5b670118a"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1610d52e-df25-496d-ad60-fab11f4cdd40/73411a5ab50060a914bf71c044a7e4ea/dotnet-sdk-5.0.102-osx-x64.tar.gz",
+            "hash": "7a3678b6b684797011d09447f6d66fbeaa42227cba8266f6a7735752d47a96be8a910fff0463fe8d021e83204f474659f69a6c192bd5f06141699e3417748554"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/17a3de4c-bb2b-4e60-baaf-85395cf0fb2b/869c6316078ffa1575e78b8005ed30a1/dotnet-sdk-5.0.102-win-arm64.exe",
+            "hash": "170e6ad7ad82a5c915a0808eecc916243f9a6330c166066e3c54ba33d4d574ff9af8f166368e4245c774056a3fb503264a900d219f95a4a6d4d737c496156202"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9b3f6a0a-345e-42d6-bdb0-7e1b671e0a5f/39daa777d12bb33d14eade85df41b5b4/dotnet-sdk-5.0.102-win-arm64.zip",
+            "hash": "58eb25e69f161e7a6aa058b3a9cbaf0fdd4c605341cf6e4f2ce61d3108c252c7de0498e857c994ab1c27f6bb35504ee11b1c35a72c8e371f128f643d3266a744"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/75483251-b77a-41a9-9ea2-05fb1668e148/2c27ea12ec2c93434c447f4009f2c2d2/dotnet-sdk-5.0.102-win-x64.exe",
+            "hash": "378dd2a216f4274fdddea6c385dba859ed7dad884214e48cca6e088529e0082486866c5d5e59e30d15baca0ea638963b6e4fb72bee1cac77ef6e12d3bb6f99b2"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8773ea25-70e8-47da-b46f-8b060f696dd6/1976c9d35ac773539c7064b39bb99b11/dotnet-sdk-5.0.102-win-x64.zip",
+            "hash": "118056d7c60d9591b0a803fb4f8941b6fa5166553d1deac625279330b05599073231ee4c4ecdc3f179d57261290b6c62ac7f34d5f89c8b06274e2346a069f79b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6fbee1fb-1fe5-40c8-b3e1-56988de60eb4/9c5b8606ebd7724b67f994adaf3ff574/dotnet-sdk-5.0.102-win-x86.exe",
+            "hash": "5ba01b2369275b02b6f62578c3fde0011fb6cd4e5e15e1c4d392cb776ae65ff5c2b3a6dac686837c8051e7d8c1c89231c49eb38497471a1d33b90ea5ab9f60d4"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bb93ed48-502c-4ff0-83a3-b6d4ac79e58b/a41fa1c797e3c67ba68780f32b596c4a/dotnet-sdk-5.0.102-win-x86.zip",
+            "hash": "079262cac8b88466cd077f3f54b9696ee1f6484764a5e6df6bd9a3cdcc9fd6e59c004f33923a9967a0efb0e3a4482034490ce3d4460a59611fe949d33d4186aa"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.102",
+          "version-display": "5.0.102",
+          "runtime-version": "5.0.2",
+          "vs-version": "16.8.4",
+          "vs-mac-version": "8.8.5",
+          "vs-support": "Visual Studio 2019 (v16.8)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+          "csharp-version": "9.0",
+          "fsharp-version": "5.0",
+          "vb-version": "15.9",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/726e260e-ce94-46c3-a169-57b2ebf5433d/5fb2a00b04b3509a0a6db63e302523a8/dotnet-sdk-5.0.102-linux-arm.tar.gz",
+              "hash": "23610a4193d8116109aaeebefa0bf023808f86d3e0a8ba52b89aa5b4b869385a5e57fc8458ff12f9ea8f359f6978498d47fd80d073ab79b2a7dfbc103b8ff903"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/4fdd4708-8990-42db-998d-36ccfa593070/d67cb90c382e4eedbca8af1aebcbbe19/dotnet-sdk-5.0.102-linux-arm64.tar.gz",
+              "hash": "031272b86f435f88963b560c14342635d892345ac9a35d59ecaf6e425de8aab15ca5c3d0685c79027364e7a323927ba90568fe7ed8610f52ee5f961aef9fcf72"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/bf715f3d-ab8a-42a1-83ce-f6e1524a9f58/8d970618369fe8e6917a49c05aac58db/dotnet-sdk-5.0.102-linux-musl-x64.tar.gz",
+              "hash": "91ac9ea608b38402b2424d7754a823fade38261904a0fbb087f982b324aacf322c3500b520507f21b4aaac40eb059d8ef6d1656fd4f161d5afde2950210e86e8"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7f736160-9f34-4595-8d72-13630c437aef/b9c4513afb0f8872eb95793c70ac52f6/dotnet-sdk-5.0.102-linux-x64.tar.gz",
+              "hash": "0ce2d5365ca39808fb71baec4584d4ec786491c3735543dc93244604ea97e242377d0987cd8b1e529258dee68f203b5780559201e7ea6d84487d6d8d433329b3"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/52bd43f7-88c9-420c-80c0-f19bae344293/a8d56f01fdb6f71adb5e22c3ddd1c3c6/dotnet-sdk-5.0.102-osx-x64.pkg",
+              "hash": "c7b6d24e86484fb692397da946509245e4b959ea1aedd49c1de7275c89ea9b61af29c88f3e40885ddd27e427d965cdf06f808c988b08c426cd797fb5b670118a"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/1610d52e-df25-496d-ad60-fab11f4cdd40/73411a5ab50060a914bf71c044a7e4ea/dotnet-sdk-5.0.102-osx-x64.tar.gz",
+              "hash": "7a3678b6b684797011d09447f6d66fbeaa42227cba8266f6a7735752d47a96be8a910fff0463fe8d021e83204f474659f69a6c192bd5f06141699e3417748554"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.exe",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/17a3de4c-bb2b-4e60-baaf-85395cf0fb2b/869c6316078ffa1575e78b8005ed30a1/dotnet-sdk-5.0.102-win-arm64.exe",
+              "hash": "170e6ad7ad82a5c915a0808eecc916243f9a6330c166066e3c54ba33d4d574ff9af8f166368e4245c774056a3fb503264a900d219f95a4a6d4d737c496156202"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/9b3f6a0a-345e-42d6-bdb0-7e1b671e0a5f/39daa777d12bb33d14eade85df41b5b4/dotnet-sdk-5.0.102-win-arm64.zip",
+              "hash": "58eb25e69f161e7a6aa058b3a9cbaf0fdd4c605341cf6e4f2ce61d3108c252c7de0498e857c994ab1c27f6bb35504ee11b1c35a72c8e371f128f643d3266a744"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/75483251-b77a-41a9-9ea2-05fb1668e148/2c27ea12ec2c93434c447f4009f2c2d2/dotnet-sdk-5.0.102-win-x64.exe",
+              "hash": "378dd2a216f4274fdddea6c385dba859ed7dad884214e48cca6e088529e0082486866c5d5e59e30d15baca0ea638963b6e4fb72bee1cac77ef6e12d3bb6f99b2"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/8773ea25-70e8-47da-b46f-8b060f696dd6/1976c9d35ac773539c7064b39bb99b11/dotnet-sdk-5.0.102-win-x64.zip",
+              "hash": "118056d7c60d9591b0a803fb4f8941b6fa5166553d1deac625279330b05599073231ee4c4ecdc3f179d57261290b6c62ac7f34d5f89c8b06274e2346a069f79b"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6fbee1fb-1fe5-40c8-b3e1-56988de60eb4/9c5b8606ebd7724b67f994adaf3ff574/dotnet-sdk-5.0.102-win-x86.exe",
+              "hash": "5ba01b2369275b02b6f62578c3fde0011fb6cd4e5e15e1c4d392cb776ae65ff5c2b3a6dac686837c8051e7d8c1c89231c49eb38497471a1d33b90ea5ab9f60d4"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/bb93ed48-502c-4ff0-83a3-b6d4ac79e58b/a41fa1c797e3c67ba68780f32b596c4a/dotnet-sdk-5.0.102-win-x86.zip",
+              "hash": "079262cac8b88466cd077f3f54b9696ee1f6484764a5e6df6bd9a3cdcc9fd6e59c004f33923a9967a0efb0e3a4482034490ce3d4460a59611fe949d33d4186aa"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.2",
+        "version-display": "5.0.2",
+        "version-aspnetcoremodule": [
+          "15.0.20336.1"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7aa18d1a-1c9a-4571-9668-3d76b5cda367/41a75d18282fa815c548be4dbc9dd55f/aspnetcore-runtime-5.0.2-linux-arm.tar.gz",
+            "hash": "b62b97931ba457aa4c023e021c1b6bbc43bcba0544440a7564538372ec39e9ab4a6ecc964e046d17c8cd253f0f7e6ae72b4852b502f223dac4b4eb8f4e50b89b"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f77f99f3-ee58-421a-bf4d-75155e361b9b/ea196b00d51607ad1796aa82697ee8da/aspnetcore-runtime-5.0.2-linux-arm64.tar.gz",
+            "hash": "154b3745c412427c3a9c7c12ef94dccbd6193d88f676ed02a4036be19de6a53fb1b027a1455f97fbb0c0811713be3e33a0ac8d414ee6b1266a82dca65ff23456"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cd4d5d32-f493-411e-9e04-ecaae0a372f0/252cc794c641b6bbdae0faeeb6e78152/aspnetcore-runtime-5.0.2-linux-musl-arm64.tar.gz",
+            "hash": "2759c590827124aac3b097449842fdc8c9a80676e3557955d317ff65950e2fbb50bda2c43c10e3cf0bdae79c2e4715a902dadef297519df6ac03a920ccaa9124"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/63fe4210-67f0-4d01-99c8-284e26978498/464f60cca9e84fc28371828552455d06/aspnetcore-runtime-5.0.2-linux-musl-x64.tar.gz",
+            "hash": "d9582bee1dc513288d386ee52bdeb9ed4d5d191d6843b68773f7979ea0d0527c35599722d700a33ce9d59752b44666b17ab7bb36da169c180965252a2742174c"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e2e14e82-11e6-430b-a1a1-b905ab23136c/35a5e31bee5151deb0532535b6a585e8/aspnetcore-runtime-5.0.2-linux-x64.tar.gz",
+            "hash": "917978eb091f4af0c403343aee9bb0eac296bc3d67b7a0e2155d211f1c3f332c72f8867f1ea726387854bf26f06b745b8080d2097d4452f69606d01c11af3555"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/97fed7d4-e8d2-4142-8b49-5f7c2c567e4f/622e19cf8c9f33acfd1cc0d0f358b66d/aspnetcore-runtime-5.0.2-osx-x64.tar.gz",
+            "hash": "5807f7f269e7eff9d5c68220d209d48f1c03110fc7af9fa729cd8ba33734e0291e5bd52a3057a065b99ad6aba658b568df0f1c0cadcd378c79bcf3d3f2d07a4e"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8b8a56ce-3f25-45fc-9bc8-043bf216a9ac/3eccd27ea8e9feeb26cde6fceaf47362/aspnetcore-runtime-5.0.2-win-arm64.zip",
+            "hash": "d3e9d765dfecc353e47a400515e15b2238185c959cc6923d2f5daba6f172cb7fe27ddee2560cf16a7c7398ae9c1ca3ff8be071a3f968e4c2baf677c4e50b2473"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/33c6f212-fcd3-428f-8ce5-9e4c0792fb58/06ffa38c3a903f8621e3ee2b78db40b7/aspnetcore-runtime-5.0.2-win-x64.exe",
+            "hash": "f404dd579b41d235178d26a8608281bb171d1554413b9ac53bbdca32e1f3e3c81f0bdc0048d209c5a5d09b9e822ad39a25eea574ac08b21fd02688f020c97052"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9d0b45f7-1c23-4766-abf3-3e259eedc961/82c4672b26e83c5f396c22171943f31d/aspnetcore-runtime-5.0.2-win-x64.zip",
+            "hash": "cfa07a205973fa39f7722f00151210543181b7aa9607cb88bfc796efbe5ee8b6faef6087cb0a19eee28a957c115bfec75e77cb8bb2a2885f06f27f3022ecbb8c"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b2fd1b9b-1b96-457a-83fe-25089fd052c4/30b503f5ecbf04586aeff2e8658d5fb6/aspnetcore-runtime-5.0.2-win-x86.exe",
+            "hash": "66d6fe4962607d2d5971723bbb778b1da96007afc6b06c7ede9d6a6e00dda3ccdcaaa10d3285012f00b8ccc11aa1b70017dca6beddf91d85d6d9f37b9e8b3931"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b5da785d-ce57-4b05-aef2-083776d6f765/cf64f37f9590bd28193a5658428342d8/aspnetcore-runtime-5.0.2-win-x86.zip",
+            "hash": "0741eaccb993515d8f4df4438de9d790796acc7a5414d5c080b94644659a56b39720e51a0612c13b1d2b50e2ed00cf15e122ae69dfe1348a597c7b592e6b5d31"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/43ea9d7a-39c9-467a-83e6-548b3faf832d/5e7d573d9c4f40d0c1192aa2319f07c5/dotnet-hosting-5.0.2-win.exe",
+            "hash": "194687f833d081288315ca87d2cf7aad3dbd2c8e24dfdb7552ae1637058c34a936fec3642952effe1b72aaf4380eccefdaecc9e4dc9c2306cd3446a7fecfb5bb",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.2",
+        "version-display": "5.0.2",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/deffc9d5-ef77-4697-ac6e-33a58ccdc409/8386e478b5823a765dc1361155360877/windowsdesktop-runtime-5.0.2-win-x64.exe",
+            "hash": "6e48c1b6717040bbb431638d80cbf612c07316e9ca6bb23ee276e140d509236cdc1e8167b35148e1565a06d1f314bcdcf764597758ad3d9dbd589a6aa75d0dac"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/adeb8933-7480-4015-abf6-ca31137ad7cd/1123096ebfa5ee3f36d77500b622e4d8/windowsdesktop-runtime-5.0.2-win-x86.exe",
+            "hash": "97f6313f40159086a544f3f52cc1f34a161bd988f12c4f31b2e86eb9ffec0a72d4c9690616d80739c9f8aa65476ab1c7c4a95e804e9333c810f9d2f6d6e7ad2e"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-12-08",
+      "release-version": "5.0.1",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.1/5.0.1.md",
+      "runtime": {
+        "version": "5.0.1",
+        "version-display": "5.0.1",
+        "vs-version": "16.8.3",
+        "vs-mac-version": "8.8",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/46b6dfbf-8da3-4e95-ae33-abd5c875bc3e/566db9b58e809f4ed6d571a1de09fc58/dotnet-runtime-5.0.1-linux-arm.tar.gz",
+            "hash": "b6cf63b4d7025a468dfaa67b1d3f28f9eb5224b040f5729202d0c144c6bf2af01596aad9cc1841a7d4250e1acc83bd9563af78f371cae17901ea8234a210e85b"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/070e2bba-564b-41d1-a5b7-2772db039ee7/4265da6f0e315dadef8742dcceab85c4/dotnet-runtime-5.0.1-linux-arm64.tar.gz",
+            "hash": "4d6c76f158a812de60201d0ec26a802bd2f2b8250041eb0c66c81996969c532e21aab9d485398634288ab885235d0df60697040c87b6fc9000e185ae39ce0c78"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f4ac9c1e-bf59-4a14-8b3c-e10064fc317d/ca9ed1110309dfd3382717031cf7f6db/dotnet-runtime-5.0.1-linux-musl-arm64.tar.gz",
+            "hash": "a09c5fea4e5ad30ae4d112290ab5bd88a5861bf3f7e1ef830e9eab8100aace3d81d4ceaa1fa34203b489708979a5f61792f26bd216d6f92ce59e0c87850960ef"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2a4a32a5-c6f1-4a4a-93b5-3be56bd78196/98fffa879c3e2e4709bee68bb452cd05/dotnet-runtime-5.0.1-linux-musl-x64.tar.gz",
+            "hash": "9a6eef8077f2d1a25a1b4ee9dd9300ac6ddd51b59ce14dd80e105cb18c27f8337517548595b8081be959d4c4d40339997931ed14b4d43aeca8d335c58bc382de"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1b2c8490-04c5-4c54-a05d-dbe4dd6c3f2c/85c2939a81302dcc822e01b5175c153e/dotnet-runtime-5.0.1-linux-x64.tar.gz",
+            "hash": "791af58eb2a4c7e7a65f0d940cfa09cda3318cb482728dbf40848543e1d04aa9ffd7e8d4fdede1b4fbc6f54250bae4e0c4a5bf208e04705f5c5f00375ac009b7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4c8830a9-e80c-4dcf-b480-bb7763957f23/dae4366068a9b3dc61e40dcfee16b54c/dotnet-runtime-5.0.1-osx-x64.pkg",
+            "hash": "59870b0cd3d47805c2b95c679f3f9f8bf9da0a3710876d8a0b7f3c390b60a949c595781d0e3b3456e2ebc487bb2c7eff8d78909d67f2cc7cda91058ac3a6e56a"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8c19388a-413c-4467-8e4a-04ebfc3cf649/951f03ab26d23ecb68d4843ac54783d6/dotnet-runtime-5.0.1-osx-x64.tar.gz",
+            "hash": "6039b20692bc6367367eaa5a6117a1065dbc5c2b24cb8294eea4319337f8b9aa2907a9fc3d00125f1df48c0ef26ecec8c097a26ac5bbdf991fdef7173734b0bc"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9db358f1-61f1-4762-a29b-5189794567d1/7bc08ab5cbde9cfdf2fbaca1ffdd27f4/dotnet-runtime-5.0.1-win-arm64.exe",
+            "hash": "f3a41ac14660ec1a2ffb64e1ae7a899a4f6e9b291847480d0cae23fb45d2ace387de0bec97a46eb082462e84e61e90dff1f9d1a618f21fe7c6ec1563b134e139"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b0dbe14a-742e-4dda-97c9-0fc63b1fabd0/d4d3325bd9b69d7eaf5642602a9260a1/dotnet-runtime-5.0.1-win-arm64.zip",
+            "hash": "2aef1591228eb5ff08535542230f6ba128e4cf944363cd941ef700eb3e4b68492d882c93a0e54f67c0ad47cc5d885bc22c9770b8d3e248ebc22c612a268809b7"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/93095e51-be33-4b28-99c8-5ae0ebba753d/501f77f4b95d2e9c3481246a3eff9956/dotnet-runtime-5.0.1-win-x64.exe",
+            "hash": "c7f458c5fa4d3b9ee27c62bf792aeb4c6addcc4c757b2794ddf673c984e783715617fe164a2ec793f1ad8ecb5715bd957884b202723309cc731e92455fbd9d5b"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/57aececf-1108-4d4d-8af4-457da60b4956/062208459fda57c607335f408a5c7a1f/dotnet-runtime-5.0.1-win-x64.zip",
+            "hash": "036a6f07982349cdc2ffc305387916216707118b7372dbd701c7a58a3ca04fc2648ed1c15b2d101b2c2ae36f2f83da345301fea809d93acfc93e34c66f0bc788"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f4fb5042-8134-4434-8835-499eb2f18b38/6a0d857f6f1833f5c54fbbe5ead028a7/dotnet-runtime-5.0.1-win-x86.exe",
+            "hash": "b8d8925dddbf7b36a30d183ea21b27eada9f2894de798d99cea9cdd45a2cc0c1584ed6d43a6981c35fb55698fbb0aedbf6f4793b74c20acc5dac98f779b877fd"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cda5eb17-f096-44f0-9405-cbf44de44513/4ebdeecf995ac2558f26f5e6fdafe2d5/dotnet-runtime-5.0.1-win-x86.zip",
+            "hash": "507ae7cc02c023ba14cceefeb7b7c7434836f3072da81a517886c446f2f1c690d30b1afa211e64493443aa62baf9ad55992bc12a0338fe04bdb2b3ac8bfa29db"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.101",
+        "version-display": "5.0.101",
+        "runtime-version": "5.0.1",
+        "vs-version": "16.8.3",
+        "vs-mac-version": "8.8",
+        "vs-support": "Visual Studio 2019 (v16.8)",
+        "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+        "csharp-version": "9.0",
+        "fsharp-version": "5.0",
+        "vb-version": "15.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/567a64a8-810b-4c3f-85e3-bc9f9e06311b/02664afe4f3992a4d558ed066d906745/dotnet-sdk-5.0.101-linux-arm.tar.gz",
+            "hash": "2b03ae553b59ad39aa22b5abb5b208318b15284889a86abdc3096e382853c28b0438e2922037f9bc974c85991320175ba48d7a6963bb112651d7027692bb5cde"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2add7523-39ec-413a-b8a7-24361cc4e599/30489ebd7ebcc723da48a64669860fd0/dotnet-sdk-5.0.101-linux-arm64.tar.gz",
+            "hash": "b26beafd7649fd9081a914909aca6302e8629f24d97ac5d7ac4c7aace007aff93e920510f3fa5a871c71ad42f2e38241115339ccf01d2399b2c9000b53607a86"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a84c2dee-3074-4c27-9b31-af0bc9a9ebcf/a8eb9a11b81c5b7119cf1578632ed186/dotnet-sdk-5.0.101-linux-musl-x64.tar.gz",
+            "hash": "e874661647b530c58e78dad4fc0537739a30c460e31678547e9dc186858c5119730d4e7a6b529bf96655ff11e8fabcecec9eb24b5faf5348fe20b8c7f3080c3a"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a0487784-534a-4912-a4dd-017382083865/be16057043a8f7b6f08c902dc48dd677/dotnet-sdk-5.0.101-linux-x64.tar.gz",
+            "hash": "398d88099d765b8f5b920a3a2607c2d2d8a946786c1a3e51e73af1e663f0ee770b2b624a630b1bec1ceed43628ea8bc97963ba6c870d42bec064bde1cd1c9edb"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0a7fa783-02e1-4785-b7b1-3c430f8825dc/764e53ff2f5722bc1b8bbc178fe25930/dotnet-sdk-5.0.101-osx-x64.pkg",
+            "hash": "bda774bacd838179dc917828056445663174d0cc811fb396bdcc0bb6d2d0d048f38a4fa2ce6f5c05d0db40ebfff5d3321ca8ac326ac07f5637ce7779724a2e1b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1193fc39-e498-407d-bf65-071172fbfb8f/56c95047d1d187cec6dd107674b650a8/dotnet-sdk-5.0.101-osx-x64.tar.gz",
+            "hash": "7aea6d5b236f8e1c0388cd15680f0939f1bf22e58027fcadbbb8fbf70f7686e5ea0df3877ac686a5713db437ac6848a4ccce73d06738969f6c46d85a6cc758ab"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b69da517-2b8c-43a8-bf88-9780392d3fab/9e0167c144036b0221f3d864fbc48af8/dotnet-sdk-5.0.101-win-arm64.exe",
+            "hash": "bc9025205f632506a5590784d33fbff019010787fe14839939da26e9e68519980b79eb495c92fd1f109af49a20983dd99ab6611d162f9f31fc9595eb6d8eab0f"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2a5cf4c4-62e7-4738-be5b-065fed5a6496/699a781da0478af053e4c435491b1fe0/dotnet-sdk-5.0.101-win-arm64.zip",
+            "hash": "b3a458835f7f433eb96e8b8ddcdac7a6c42167e5aa243adc7a9a0d4a834967135b2b111af5841843ca87cc5c0ba176a1d98bc362b624ddf20d01736ffcf556e8"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/acff3e6a-d8d6-4c2a-a0cb-1853b58055cc/7910b2a414caa17d30b0cb82583cb542/dotnet-sdk-5.0.101-win-x64.exe",
+            "hash": "1a70df36a57f2c45fe08741a9181a95c94aa93c765c787d4981646e17dd29daf2b2111f11a3a46cebcebc108d9e11bcd5b510f07160f43881abf49cfcf08ce9f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d96f04db-f33a-4c0a-bcaf-4fe94559b974/5ad3c8ea7232b361cc1acd89ae4c876c/dotnet-sdk-5.0.101-win-x64.zip",
+            "hash": "7298d1b370b2055f95c03a628f78dce97470434a76907e20ad1ea14b55bdb0a67b2a78f5b5ec928b914df735e89ae9f3a8033d0fe2112a38998581598d35e931"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f3ab5b2d-90a2-4235-ba83-b431af07cf08/a79a3138bbacde2e44341de3fe89242a/dotnet-sdk-5.0.101-win-x86.exe",
+            "hash": "d15f8a43ecc4d84744cec79374c70addc8cb91aa9b5625d7171314787f711a6d53292efe88bf1694b664e012a4c2a469966185b7aef5d7f260f51a3b817f3fdd"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/91018cd2-d4e4-45da-920d-1a40970ed5bf/68efbc308fa59cc2c3ce41fe539d6179/dotnet-sdk-5.0.101-win-x86.zip",
+            "hash": "d22252a378fc566c3e3209e463905e51cc7dfa9f5dbc795513889025b07fee927e681c3392a8778e44bed4d084ede949917b81aac5e6e3ec10b0abbf4b1c59c4"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.101",
+          "version-display": "5.0.101",
+          "runtime-version": "5.0.1",
+          "vs-version": "16.8.3",
+          "vs-mac-version": "8.8",
+          "vs-support": "Visual Studio 2019 (v16.8)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+          "csharp-version": "9.0",
+          "fsharp-version": "5.0",
+          "vb-version": "15.9",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/567a64a8-810b-4c3f-85e3-bc9f9e06311b/02664afe4f3992a4d558ed066d906745/dotnet-sdk-5.0.101-linux-arm.tar.gz",
+              "hash": "2b03ae553b59ad39aa22b5abb5b208318b15284889a86abdc3096e382853c28b0438e2922037f9bc974c85991320175ba48d7a6963bb112651d7027692bb5cde"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2add7523-39ec-413a-b8a7-24361cc4e599/30489ebd7ebcc723da48a64669860fd0/dotnet-sdk-5.0.101-linux-arm64.tar.gz",
+              "hash": "b26beafd7649fd9081a914909aca6302e8629f24d97ac5d7ac4c7aace007aff93e920510f3fa5a871c71ad42f2e38241115339ccf01d2399b2c9000b53607a86"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a84c2dee-3074-4c27-9b31-af0bc9a9ebcf/a8eb9a11b81c5b7119cf1578632ed186/dotnet-sdk-5.0.101-linux-musl-x64.tar.gz",
+              "hash": "e874661647b530c58e78dad4fc0537739a30c460e31678547e9dc186858c5119730d4e7a6b529bf96655ff11e8fabcecec9eb24b5faf5348fe20b8c7f3080c3a"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a0487784-534a-4912-a4dd-017382083865/be16057043a8f7b6f08c902dc48dd677/dotnet-sdk-5.0.101-linux-x64.tar.gz",
+              "hash": "398d88099d765b8f5b920a3a2607c2d2d8a946786c1a3e51e73af1e663f0ee770b2b624a630b1bec1ceed43628ea8bc97963ba6c870d42bec064bde1cd1c9edb"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0a7fa783-02e1-4785-b7b1-3c430f8825dc/764e53ff2f5722bc1b8bbc178fe25930/dotnet-sdk-5.0.101-osx-x64.pkg",
+              "hash": "bda774bacd838179dc917828056445663174d0cc811fb396bdcc0bb6d2d0d048f38a4fa2ce6f5c05d0db40ebfff5d3321ca8ac326ac07f5637ce7779724a2e1b"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/1193fc39-e498-407d-bf65-071172fbfb8f/56c95047d1d187cec6dd107674b650a8/dotnet-sdk-5.0.101-osx-x64.tar.gz",
+              "hash": "7aea6d5b236f8e1c0388cd15680f0939f1bf22e58027fcadbbb8fbf70f7686e5ea0df3877ac686a5713db437ac6848a4ccce73d06738969f6c46d85a6cc758ab"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.exe",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/b69da517-2b8c-43a8-bf88-9780392d3fab/9e0167c144036b0221f3d864fbc48af8/dotnet-sdk-5.0.101-win-arm64.exe",
+              "hash": "bc9025205f632506a5590784d33fbff019010787fe14839939da26e9e68519980b79eb495c92fd1f109af49a20983dd99ab6611d162f9f31fc9595eb6d8eab0f"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2a5cf4c4-62e7-4738-be5b-065fed5a6496/699a781da0478af053e4c435491b1fe0/dotnet-sdk-5.0.101-win-arm64.zip",
+              "hash": "b3a458835f7f433eb96e8b8ddcdac7a6c42167e5aa243adc7a9a0d4a834967135b2b111af5841843ca87cc5c0ba176a1d98bc362b624ddf20d01736ffcf556e8"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/acff3e6a-d8d6-4c2a-a0cb-1853b58055cc/7910b2a414caa17d30b0cb82583cb542/dotnet-sdk-5.0.101-win-x64.exe",
+              "hash": "1a70df36a57f2c45fe08741a9181a95c94aa93c765c787d4981646e17dd29daf2b2111f11a3a46cebcebc108d9e11bcd5b510f07160f43881abf49cfcf08ce9f"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d96f04db-f33a-4c0a-bcaf-4fe94559b974/5ad3c8ea7232b361cc1acd89ae4c876c/dotnet-sdk-5.0.101-win-x64.zip",
+              "hash": "7298d1b370b2055f95c03a628f78dce97470434a76907e20ad1ea14b55bdb0a67b2a78f5b5ec928b914df735e89ae9f3a8033d0fe2112a38998581598d35e931"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f3ab5b2d-90a2-4235-ba83-b431af07cf08/a79a3138bbacde2e44341de3fe89242a/dotnet-sdk-5.0.101-win-x86.exe",
+              "hash": "d15f8a43ecc4d84744cec79374c70addc8cb91aa9b5625d7171314787f711a6d53292efe88bf1694b664e012a4c2a469966185b7aef5d7f260f51a3b817f3fdd"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/91018cd2-d4e4-45da-920d-1a40970ed5bf/68efbc308fa59cc2c3ce41fe539d6179/dotnet-sdk-5.0.101-win-x86.zip",
+              "hash": "d22252a378fc566c3e3209e463905e51cc7dfa9f5dbc795513889025b07fee927e681c3392a8778e44bed4d084ede949917b81aac5e6e3ec10b0abbf4b1c59c4"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.1",
+        "version-display": "5.0.1",
+        "version-aspnetcoremodule": [
+          "15.0.20336.1"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/11977d43-d937-4fdb-a1fb-a20d56f1877d/73aa09b745586ac657110fd8b11c0275/aspnetcore-runtime-5.0.1-linux-arm.tar.gz",
+            "hash": "a7aa5431d79b69279a1ee9b39503030247001b747ccdd23411ff77b4f88458a49c198de35d1c1fa452684148ad9e1a176c27da97c8ff03df9ee5c3c10909c8b5"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e12f9b23-cb47-4718-9903-8a000f85a442/d1a6a6c75cc832ad8187f5bce0d6234a/aspnetcore-runtime-5.0.1-linux-arm64.tar.gz",
+            "hash": "794bba781849970be139090e0d9a38530358ad13ba701369096c417cef260b34543f56270c0628696ec33299a999bfbee6d8e6f52722eda845f01f61ea9bf0ff"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/09c5b087-033d-4e97-a945-c80b9380d5fb/48e3f28d6a8eebe881d7ceb8192f7806/aspnetcore-runtime-5.0.1-linux-musl-arm64.tar.gz",
+            "hash": "62e72900eb433c32d26efd975ad41bcc934959e67c34c8a6176056da0856ee6918dd526dc66d01316ac5773061bd0b691e224d5fd581c8ecbdd9255d5bb8b8d4"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b87727dd-e0e2-4253-b6f8-ba541195465c/78362e21fbb5b7faf869004993eea290/aspnetcore-runtime-5.0.1-linux-musl-x64.tar.gz",
+            "hash": "004fe94ba94b23eadd91ac2a95d175ee41b5550cdda9c5f48b0c090848562e1b5a33c9875517e9ff4d3c3a18b7c6f2c74d14c0860d3f4c68d388939412a72452"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6bea1cea-89e8-4bf7-9fc1-f77380443db1/0fb741b7d587cce798ebee80732196ef/aspnetcore-runtime-5.0.1-linux-x64.tar.gz",
+            "hash": "fec655aed2e73288e84d940fd356b596e266a3e74c37d9006674c4f923fb7cde5eafe30b7dcb43251528166c02724df5856e7174f1a46fc33036b0f8db92688a"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f1c49188-548d-4853-9c72-909f47b7fa81/e01f1507b8b8643caef55dda46fe7ec5/aspnetcore-runtime-5.0.1-osx-x64.tar.gz",
+            "hash": "2471486939d71764dc1d5f2f26f7111481863aaf837142917ec4720eaf04f4a69c01efa25339da496cfa4f719d80be09cc659b4e4da7ae7d87469a3516e7ec37"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7413850b-de56-49bf-b2ed-564d4ef1d7f9/abfbfa6e9b5e612261db6fafc6fbaa6d/aspnetcore-runtime-5.0.1-win-arm64.zip",
+            "hash": "46bdaf5e454e58592be38597aaad5782fc819eb198463b50536380aa5b0818794fa73de3a6383c239dcde9aff02be1e3bf7467c87b8cd15327ed5b2dc8a98016"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/48dd125b-b9ca-4fc7-b26c-558bff5bee13/214be31c3239444d4a9cfdf0574f3cd8/aspnetcore-runtime-5.0.1-win-x64.exe",
+            "hash": "d0d9b178fc5dc645750ad45457817b032d7b4ba1bf319c828a6015e9d8301fe9d6f9b747c7224e48f33ea00dd239c4dd174b59cb662658d76fb2be8e87bd41d7"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/542a8d9d-6450-4630-aa2d-277b258d85ad/f24090c31b34d6830b513287efd59d70/aspnetcore-runtime-5.0.1-win-x64.zip",
+            "hash": "b36513456f4cf860b8999c8831021b2b2b21611e4c66a81a8e13604270bfe4f741f1cbfa1778b459c17db60f3406083167f147ad1aa09c248a0e002c4ed2768c"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7d6ed29e-5c0d-47b4-8436-7f1d21a0bca4/e8609f033ad936c117f2d90b86fd05c4/aspnetcore-runtime-5.0.1-win-x86.exe",
+            "hash": "8eb37ea4f63c419236aad2f864012ccc96b3d9d4362d3ae32ed219f1403aee170e4d3b25454e2685255fd3e6ff225eae75b8d9b771582f35cc064530f6f0887e"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c7fc17df-5e2e-402c-b4de-d689fddd075f/c523e5a4b3f37960ca89a52b99ab98cb/aspnetcore-runtime-5.0.1-win-x86.zip",
+            "hash": "c32957bbfc7536a56ec24bf6884628e2102bf9f25bb8f0336d328e06f9df8afc4e9e36523520e7687ce0d84b2cc72e668d416ebcfde769e605a9409e2df03116"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b6271a4b-db02-4245-bf99-974ea96b7ca3/29389344a55c6792bd4e717a254168a2/dotnet-hosting-5.0.1-win.exe",
+            "hash": "776aa4d666c93024af8130ddf21e4d406130ea4ff8e4b14067178a994b67dc79d59792fa8909a52accfbd0a7b6ada60a922e108ac5f67e4cdc00a40c63ebd043",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.1",
+        "version-display": "5.0.1",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c6a74d6b-576c-4ab0-bf55-d46d45610730/f70d2252c9f452c2eb679b8041846466/windowsdesktop-runtime-5.0.1-win-x64.exe",
+            "hash": "ac1be00ce52296148a84ddbcd92c7a78b1c6e09cf65d23fb2859ef050c3ad87eacf70745deb1cea0c64832486eb0b3470219dcb80ed034419bf6673487f2bac6"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/55bb1094-db40-411d-8a37-21186e9495ef/1a045e29541b7516527728b973f0fdef/windowsdesktop-runtime-5.0.1-win-x86.exe",
+            "hash": "c2dd979418e353940598ca721ea7927052f043282a219ca26244c0811e2359057719115a5b251cde98fd3a9bca05bdba551a57bf42df035a66de44a69a6e6309"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-11-10",
+      "release-version": "5.0.0",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.0/5.0.0.md",
+      "runtime": {
+        "version": "5.0.0",
+        "version-display": "5.0.0",
+        "vs-version": "16.8.0",
+        "vs-mac-version": "8.8",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5fc4659b-86c2-4e8f-b409-853e6d8224a5/6de0fc8c6e26f308bf246aaa967c9fc1/dotnet-runtime-5.0.0-linux-arm.tar.gz",
+            "hash": "b186bcf68b1fb6fbad750e0716b323e6f474f1977ce413646ecf2b009e2590c66956c44b883cc26263e65d9356ae8cd6f738476cb66a9434cc50d1fc4b11e790"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4b114207-eaa2-40fe-8524-bd3c56b2fd9a/1d74fdea8701948c0150c39645455b2f/dotnet-runtime-5.0.0-linux-arm64.tar.gz",
+            "hash": "c7a5ae2bd4e0edbd3b681c2997ebf1633bfa1cd30a4333cb63fc9945b4e7c9278282516fb5bc22c710ce6fb59dc2e28230c07b0e99826165fa148406ab8afb0f"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b6cec2d5-8ff0-4318-86a5-b63af83122f3/b8292678eff99395e008367371d83bc8/dotnet-runtime-5.0.0-linux-musl-arm64.tar.gz",
+            "hash": "b2858df7e3bc9d45f2014e0d1cab4490b511694881c713dc5af8e472bca6b218d6a9fc94776727310a8e14a38a29d66475f67d3d02783132125c7e9d285d1379"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a4cbacdd-717e-415d-8695-1503ece2616e/c947d9acc995e9b055068bf4cbd8c81c/dotnet-runtime-5.0.0-linux-musl-x64.tar.gz",
+            "hash": "c112bdc4308c0b49fa4f4f9845bf13bfcfe2debed9166e6e6922f389c043d6f7f55a7cc3e03778c08df3ffd415059b90dfb87ce84c95a0fb1de0a6e9f4428b6f"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c84d49aa-200c-4400-a517-87cce5b7516d/94c89b00380eb212e19538b05f8cb968/dotnet-runtime-5.0.0-linux-x64.tar.gz",
+            "hash": "d4d67df5ff5f6dde0d865a6e87559955bd57429df396cf7d05fe77f09e6220c67dc5e66439b1801ca4d301a62f81f666122bf4b623b31a46b861677dcafc62a4"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9c1b257d-1db8-4dd6-8012-9e1371d28b19/ab6812447b1097b19f5306b2d020c7c1/dotnet-runtime-5.0.0-osx-x64.pkg",
+            "hash": "e41d5565b608e2aafc848852bcbf455e9c08023b5fe582bca921839ea79fb5e956916436b4f46cdc1b9a37ed32d322d77a96bcf6e6385a6e8e62f224cbbeabff"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/112291a5-e3e0-4741-9c66-c9cea6231f3f/3ebd75dfda0492fcbf50c6f939762c46/dotnet-runtime-5.0.0-osx-x64.tar.gz",
+            "hash": "eba97211e158a0c1c15b03a79b42027319d83456dc377a2513c32defb560cd43fcfa1e84154a43243b77ca6b454c4dbc32be4153f0ba9c954c7b1e69ab5d7c53"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fa94df7a-0350-4ac8-b789-1c4882d753db/acf0462ca7725bd9f5831a201843e19a/dotnet-runtime-5.0.0-win-arm64.exe",
+            "hash": "b9f17c8a8683710b67e938e65aa90877f2631a54baf02ee1bf8925bf1b858ae9745052209fbdb8b06e4a7289842b44f0342dfe13300be15005a953d12b24830c"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3ef45865-b9d4-413f-86cb-37baee7c1419/ecaaaae8560a0785668fe1739b3ad521/dotnet-runtime-5.0.0-win-arm64.zip",
+            "hash": "b44679eba929f66a488e0e47feb127ab4dba3102422c7df5d6c869440c309f85c5decd179a19ec5ba9897ca3b8592453bcd50ac2530cf4f2c8132562d8ab6a4b"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/36a9dc4e-1745-4f17-8a9c-f547a12e3764/ae25e38f20a4854d5e015a88659a22f9/dotnet-runtime-5.0.0-win-x64.exe",
+            "hash": "989d523afe64e927bef95386b06148e685ef387568dad61cd09ad1ce3805308d835ec765089b1fe622d81a5617ae721af5c9064f195524c1b2a9165111d05c31"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4c86f8a0-8f0b-454f-9419-081c2f21b348/52a1d3c12effa2bc1b552a4fd9f53d20/dotnet-runtime-5.0.0-win-x64.zip",
+            "hash": "968f2aff18aabc8f9ef0e1a6a3c0c3704d7a010ed453f0d56ded804513ccff913032461f1dbe0ce89522e85fbe5593d444f4310e8fdf7de7c7b72d01912086f1"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a7e15da3-7a15-43c2-a481-cf50bf305214/c69b951e8b47101e90b1289c387bb01a/dotnet-runtime-5.0.0-win-x86.exe",
+            "hash": "85e657528350fe95996b6f89ab9d836be91d47b82b3c3523c057f61b351c8274e653fef5e77562ef8ac049ed24cd22186b04594828b26dca69a3fcd792d17d72"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eec32c52-40f5-4ee4-8b3f-a78126c8d2f0/f526f4a1abd052bb58848f18775597ed/dotnet-runtime-5.0.0-win-x86.zip",
+            "hash": "45f31e5709abc69ba29647565ca1abc2a4d3512de257dd178d7efa4ad5715f0e273ae521a47046aaa606c255d007d2764fe02121fa21a9fbdd3ecd612e147534"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100",
+        "version-display": "5.0.100",
+        "runtime-version": "5.0.0",
+        "vs-version": "16.8.0",
+        "vs-mac-version": "8.8",
+        "vs-support": "Visual Studio 2019 (v16.8)",
+        "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+        "csharp-version": "9.0",
+        "fsharp-version": "5.0",
+        "vb-version": "15.9",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e8912d3b-483b-4d6f-bd3a-3066b3194313/20f2261fe4e16e55df4bbe03c65a7648/dotnet-sdk-5.0.100-linux-arm.tar.gz",
+            "hash": "c61a0910e34a5d7bffee46835242c24a153bf346e0ef1b048a47d12e60408aa722cec0a08fa1461ab615a4f0d09ef470c479d393f93929837f18699c745c1314"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/27840e8b-d61c-472d-8e11-c16784d40091/ae9780ccda4499405cf6f0924f6f036a/dotnet-sdk-5.0.100-linux-arm64.tar.gz",
+            "hash": "5fceac0a9468097d66af25516da597eb4836b294ed1647ba272ade5c8faea2ed977a95d9ce720c44d71607fa3a0cf9de55afe0e66c0c89ab1cc6736945978204"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7139f9c3-5c9a-41f9-b49a-2a2bc21886fc/90a1fc71b18b7d64baa83c2325eff7b2/dotnet-sdk-5.0.100-linux-musl-x64.tar.gz",
+            "hash": "c6c7a505ca4152bdc73869f296b0d8d2f78fd764971656ab5a1d7df24904113280617bfe796b98a1b1cdfe81cb65ccbe0647d4faf3b002b3cc06d18e2b7f0d0d"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/820db713-c9a5-466e-b72a-16f2f5ed00e2/628aa2a75f6aa270e77f4a83b3742fb8/dotnet-sdk-5.0.100-linux-x64.tar.gz",
+            "hash": "bec37bfb327c45cc01fd843ef93b22b556f753b04724bba501622df124e7e144c303a4d7e931b5dbadbd4f7b39e5adb8f601cb6293e317ad46d8fe7d52aa9a09"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3bdcd7d2-1444-4f7d-a254-504a994ffe39/e4f42b83604673f971748c722aa20bec/dotnet-sdk-5.0.100-osx-x64.pkg",
+            "hash": "1faeea85cdeb0abe976f65939cd6a27ffd830c313f1e31518022568f9ecf4ad98bb0512fc39ac898a3d83d8d79d72fe44bad09ff80803f07d1dbdd34ef4a3a7d"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0871336f-9a83-4ce4-80ca-625d03003369/2eb78456e0b106e9515dc03898d3867a/dotnet-sdk-5.0.100-osx-x64.tar.gz",
+            "hash": "69ccc7c686ac06f6c658d118f59cf1a0e7284b4570375dd88d3e3043098e311745922301f2650d159624d09c4d39a1f3cbdd5daee0e408eef915de839e3bce8f"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/95ac9cc2-49ec-43ca-9f2a-9230e4d6052e/493cdd41352863d840a7cd0997e4c9e0/dotnet-sdk-5.0.100-win-arm64.exe",
+            "hash": "5386b13e10eb2a34be3ede870c9da145fb1b9259be8ed83a22a490f1bc829ac90c1671d328dca43d6d923278d9d1342fc69c5fc23d2407e6cc80d362d365d575"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f1bf8f4c-ba17-4144-8e4c-e46fd04d8147/f36a2d158383f78e8cea835219830822/dotnet-sdk-5.0.100-win-arm64.zip",
+            "hash": "d6f5057d5b31521219aa8c0a3e5195eae1892e5281109343c4f5605ef95553bc35471be92e0a68cd26b7d80b2b9c5653ddcedcba2a84d14a3b8f44457073e15f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2892493e-df43-409e-af68-8b14aa75c029/53156c889fc08f01b7ed8d7135badede/dotnet-sdk-5.0.100-win-x64.exe",
+            "hash": "14c6a264451c48b6f7b0266adc9a0ffe0ebf9b954068531585e503e0c6b7ed4921822fb64de0bca31bf4065cd3ecf1d61bd6aa242c5e930affbdcb2bb6eaaf5d"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7b78bdaa-d0ac-41c4-9fdc-5820d7dc79b6/cea499dd314ba6394ccea51a2a2dcda9/dotnet-sdk-5.0.100-win-x64.zip",
+            "hash": "6836916bc6f3f9f7c183eb49fa1f6130640bcf623f310785466cb36c98f0554d656ec69ce3524f22d1e0d21528796182c7b4f0ed7c66e37cbc0ecbcd9f59bcd5"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/caa07f2f-f736-4115-80a1-b9c86fe3e55e/bd8df5ab7aad36795ef2c017594fafad/dotnet-sdk-5.0.100-win-x86.exe",
+            "hash": "66b2b126cacde2ac31f66aae091a472ab336b14802bb04c54d70f794ac67392c318644ea393e8dbc8b493dfbc5f0c6ddcdd13dc01f17d900650f32973558a999"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/46d55dd1-1630-472c-a951-edb8b0ab23e6/70d97e9619f0d086a99eeef0a465084d/dotnet-sdk-5.0.100-win-x86.zip",
+            "hash": "66bb16f536d7223544c97a33499ab35d35ca0648b80012a9fa7ab13184ac84ecf4b0a2ffa9b2c7829cf525777bca873f62d57989a8c68baa1f0ef327b1b3763c"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100",
+          "version-display": "5.0.100",
+          "runtime-version": "5.0.0",
+          "vs-version": "16.8.0",
+          "vs-mac-version": "8.8",
+          "vs-support": "Visual Studio 2019 (v16.8)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+          "csharp-version": "9.0",
+          "fsharp-version": "5.0",
+          "vb-version": "15.9",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/e8912d3b-483b-4d6f-bd3a-3066b3194313/20f2261fe4e16e55df4bbe03c65a7648/dotnet-sdk-5.0.100-linux-arm.tar.gz",
+              "hash": "c61a0910e34a5d7bffee46835242c24a153bf346e0ef1b048a47d12e60408aa722cec0a08fa1461ab615a4f0d09ef470c479d393f93929837f18699c745c1314"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/27840e8b-d61c-472d-8e11-c16784d40091/ae9780ccda4499405cf6f0924f6f036a/dotnet-sdk-5.0.100-linux-arm64.tar.gz",
+              "hash": "5fceac0a9468097d66af25516da597eb4836b294ed1647ba272ade5c8faea2ed977a95d9ce720c44d71607fa3a0cf9de55afe0e66c0c89ab1cc6736945978204"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7139f9c3-5c9a-41f9-b49a-2a2bc21886fc/90a1fc71b18b7d64baa83c2325eff7b2/dotnet-sdk-5.0.100-linux-musl-x64.tar.gz",
+              "hash": "c6c7a505ca4152bdc73869f296b0d8d2f78fd764971656ab5a1d7df24904113280617bfe796b98a1b1cdfe81cb65ccbe0647d4faf3b002b3cc06d18e2b7f0d0d"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/820db713-c9a5-466e-b72a-16f2f5ed00e2/628aa2a75f6aa270e77f4a83b3742fb8/dotnet-sdk-5.0.100-linux-x64.tar.gz",
+              "hash": "bec37bfb327c45cc01fd843ef93b22b556f753b04724bba501622df124e7e144c303a4d7e931b5dbadbd4f7b39e5adb8f601cb6293e317ad46d8fe7d52aa9a09"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3bdcd7d2-1444-4f7d-a254-504a994ffe39/e4f42b83604673f971748c722aa20bec/dotnet-sdk-5.0.100-osx-x64.pkg",
+              "hash": "1faeea85cdeb0abe976f65939cd6a27ffd830c313f1e31518022568f9ecf4ad98bb0512fc39ac898a3d83d8d79d72fe44bad09ff80803f07d1dbdd34ef4a3a7d"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0871336f-9a83-4ce4-80ca-625d03003369/2eb78456e0b106e9515dc03898d3867a/dotnet-sdk-5.0.100-osx-x64.tar.gz",
+              "hash": "69ccc7c686ac06f6c658d118f59cf1a0e7284b4570375dd88d3e3043098e311745922301f2650d159624d09c4d39a1f3cbdd5daee0e408eef915de839e3bce8f"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.exe",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/95ac9cc2-49ec-43ca-9f2a-9230e4d6052e/493cdd41352863d840a7cd0997e4c9e0/dotnet-sdk-5.0.100-win-arm64.exe",
+              "hash": "5386b13e10eb2a34be3ede870c9da145fb1b9259be8ed83a22a490f1bc829ac90c1671d328dca43d6d923278d9d1342fc69c5fc23d2407e6cc80d362d365d575"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f1bf8f4c-ba17-4144-8e4c-e46fd04d8147/f36a2d158383f78e8cea835219830822/dotnet-sdk-5.0.100-win-arm64.zip",
+              "hash": "d6f5057d5b31521219aa8c0a3e5195eae1892e5281109343c4f5605ef95553bc35471be92e0a68cd26b7d80b2b9c5653ddcedcba2a84d14a3b8f44457073e15f"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2892493e-df43-409e-af68-8b14aa75c029/53156c889fc08f01b7ed8d7135badede/dotnet-sdk-5.0.100-win-x64.exe",
+              "hash": "14c6a264451c48b6f7b0266adc9a0ffe0ebf9b954068531585e503e0c6b7ed4921822fb64de0bca31bf4065cd3ecf1d61bd6aa242c5e930affbdcb2bb6eaaf5d"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7b78bdaa-d0ac-41c4-9fdc-5820d7dc79b6/cea499dd314ba6394ccea51a2a2dcda9/dotnet-sdk-5.0.100-win-x64.zip",
+              "hash": "6836916bc6f3f9f7c183eb49fa1f6130640bcf623f310785466cb36c98f0554d656ec69ce3524f22d1e0d21528796182c7b4f0ed7c66e37cbc0ecbcd9f59bcd5"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/caa07f2f-f736-4115-80a1-b9c86fe3e55e/bd8df5ab7aad36795ef2c017594fafad/dotnet-sdk-5.0.100-win-x86.exe",
+              "hash": "66b2b126cacde2ac31f66aae091a472ab336b14802bb04c54d70f794ac67392c318644ea393e8dbc8b493dfbc5f0c6ddcdd13dc01f17d900650f32973558a999"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/46d55dd1-1630-472c-a951-edb8b0ab23e6/70d97e9619f0d086a99eeef0a465084d/dotnet-sdk-5.0.100-win-x86.zip",
+              "hash": "66bb16f536d7223544c97a33499ab35d35ca0648b80012a9fa7ab13184ac84ecf4b0a2ffa9b2c7829cf525777bca873f62d57989a8c68baa1f0ef327b1b3763c"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0",
+        "version-display": "5.0.0",
+        "version-aspnetcoremodule": [
+          "15.0.20300.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1c5366e8-9b74-4017-96ae-47fc08832c22/504aed87590bd99c49d053bc6f980b6b/aspnetcore-runtime-5.0.0-linux-arm.tar.gz",
+            "hash": "998b4a4b6f8f945b7521f560b3ca330c1d6e5e7f60d31727389cb1adef45a818846bf083dd8735fc9996eb030ecd1cc93f799ed7ab531ce0d11ef01bcfdde95f"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ac555882-afa3-4f5b-842b-c4cec2ae0e90/84cdd6d47a9f79b6722f0e0a9b258888/aspnetcore-runtime-5.0.0-linux-arm64.tar.gz",
+            "hash": "13e174de1cf10135531468c2a76852de2c37253f4d8b487ff25d249c2d7a1c590475545ca246515338baff2950422ec6c5ffe2180e8327f25cb5f9fede696ccc"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0f38125f-70f0-451c-8f4e-e7e0b102c1c6/96fce6e16fcbe341657e44023ab3c95c/aspnetcore-runtime-5.0.0-linux-musl-arm64.tar.gz",
+            "hash": "fb0703d66b223fed4d9d7d18c943e3a56fe7048b747a98edfce5abbebf37bcbf9e76bba50822704d028ecd004a48d72a1cab9a1ef4f2a99acb3f7fa6480349d9"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d97e046-dde3-4d76-8d93-4ca21a628ba0/820bd340cad73af0cf5d568baf48bf83/aspnetcore-runtime-5.0.0-linux-musl-x64.tar.gz",
+            "hash": "1f36800145889f6e8dd823deffce309094d35c646e231fd36fa488c83df76db7b6166eea1d50db0513e0730ca33540cb081f7675ea255135e4e553e7aa5ef2ce"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ff9a5b2e-704b-4ff2-bf2f-4bac619915af/e771f72b10ad5160ab5f3d70c287e948/aspnetcore-runtime-5.0.0-linux-x64.tar.gz",
+            "hash": "402046ee144915ef7d75a788cf19552eea56cf897681721b74bfc403fd366f71eb7e56f6b83ea299b6b812c6b87378c15e7bfe249415427dcd147dfeacd084d0"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/173b9b16-4d0d-4387-acf0-f113a359ee77/cbc2f6c00ac56c44bda0e3c960e38bd1/aspnetcore-runtime-5.0.0-osx-x64.tar.gz",
+            "hash": "b47a9958f5412b22edb2cb47702ad442c389901ede3ca2a7f75d901f8ed608494431849f498c2191327065ff1db52a1658b1a8c0feb53aaec4c814fb0baf6818"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/11b4ed9d-5cf4-4037-a6ed-87a14940637d/a3da5eb099fbd1649dbc90b2b00dc0ad/aspnetcore-runtime-5.0.0-win-arm64.zip",
+            "hash": "4a2b3739dc0b1dd8577cf68aa3d382a52bb9be0470552213b658f3a59d504823d83a903f774a34470220f058cdc3dd068318344a1104950ad5ffc8c0d13cef09"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/92866d29-a298-4cab-b501-a65e43820f97/88d287b9fb4a12cfcdf4a6be85f4a638/aspnetcore-runtime-5.0.0-win-x64.exe",
+            "hash": "723ecbb1158d6b2878c1983b48f4dc4e8487b5dac15992ed1fe5bf1ccb5ee2c9332eb8cad8a452d585fdc2b99e38c337e87d03eec9616694f1e6e99825ba455f"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6ddc3153-7600-4e14-9acb-b672c26c15bb/7ffc45bc16916fbde8a0f4abebe72df0/aspnetcore-runtime-5.0.0-win-x64.zip",
+            "hash": "ead6b1e12361261124bb89de1e77dba9469ce00483d963b237ce1e2a17500e420c2bd078c2732e7ce269e23ee3922b880f88ade9c1426c7170045fec1818ece4"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/115edeeb-c883-45be-90f7-8db7b6b3fa2f/6bf92152b2b9fa9c0d0b08a13b60e525/aspnetcore-runtime-5.0.0-win-x86.exe",
+            "hash": "594e013abc6fbe96f0d95f6c69be9522da985c8e627166492c39f5db0ffcffb445549ccfd61171ef6e8be374afcb477455ed7b189b91eb9aa6656ac7e0f65da2"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/43ced5d3-87a1-4891-9877-fa2dda4091d3/7658b8441a46d1ba9650fea4fdd429c0/aspnetcore-runtime-5.0.0-win-x86.zip",
+            "hash": "a36b96c34c0c6a7e47f484a45c9ba02f1e7b44ea7dfed9289d0e37ea4af366bb0a8e0a4dd5a67efab5d1fd01a42d67ece1a001ea7b15b050ef35eea67094df60"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/08d642f7-8ade-4de3-9eae-b77fd05e5f01/503da91e7ea62d8be06488b014643c12/dotnet-hosting-5.0.0-win.exe",
+            "hash": "a887fa32615237d6174f5b8c537c25d2413f928d9f24c0414356b2d0a01bde7ee5874db45e344dbf7c8de4ce1c7034a175c29bfd0ce1f27820412098adc5b64e",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0",
+        "version-display": "5.0.0",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1b3a8899-127a-4465-a3c2-7ce5e4feb07b/1e153ad470768baa40ed3f57e6e7a9d8/windowsdesktop-runtime-5.0.0-win-x64.exe",
+            "hash": "243986604ea7ec1332960536e6a534b7755d2bf29a585ca7e5bcd60570ab72c0f8ace0755b0e1a0a5972dc77c28bb3a5f152f8ed84d2acb2fa76c22916ac4376"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b2780d75-e54a-448a-95fc-da9721b2b4c2/62310a9e9f0ba7b18741944cbae9f592/windowsdesktop-runtime-5.0.0-win-x86.exe",
+            "hash": "144df140b566aa76b4bbc6259288d832df36935325c90af4cb9c28027f8625bdddd8369b03787d78e7a0502597ed809fbd20411549b4b93b127e88ce94b36e27"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-10-13",
+      "release-version": "5.0.0-rc.2",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-rc.2.md",
+      "runtime": {
+        "version": "5.0.0-rc.2.20475.5",
+        "version-display": "5.0.0-rc.2",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/91f51f33-238d-46bd-9d28-4d07667c49fb/693e99d7e048f96ba1237b19a9c848a9/dotnet-runtime-5.0.0-rc.2.20475.5-linux-arm.tar.gz",
+            "hash": "37b0f89157a748bca6c8d7a01f5e8d6438d60208e77b6734d4624ac3c1c29997aa28b7f01a86c5d6e1fb187ab3d61643a655cc6db6bb5cd01df3f6039e91103b"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f765599d-3130-4825-acc5-92c717a06013/22fcf79920ad59b0cce1653a1171a80e/dotnet-runtime-5.0.0-rc.2.20475.5-linux-arm64.tar.gz",
+            "hash": "0ea8c2461262f27da9ff83877c9f53ba4bc043d829df1978cfdc6158cc58be678fd84f60935a02ad245d70c6e8fff05bb025cfd35419b3d335291688114c0021"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9f24d1a3-44ca-40f4-a129-aa71dc649f87/0eaaade7b6919a1f968e62a1f1cadfbe/dotnet-runtime-5.0.0-rc.2.20475.5-linux-musl-arm64.tar.gz",
+            "hash": "015ed92c4a4766a9a2f0e2fd6d138be1a886d8ecef9b1765a4b3c24767d7326cb00cd3d4aabc04921d65827ce72bfbbf17097ebd2a7b3e3c12b9a8fc95970939"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ef5fba19-c738-45ba-ac4e-bea399bb1086/ae704db109eec283eee4ecb0cbab491c/dotnet-runtime-5.0.0-rc.2.20475.5-linux-musl-x64.tar.gz",
+            "hash": "2e4baec3c3746210cae4e920046ec6bede9caed1cdf30382295fd1b203bf08e6bee5bee0da3067f0317b31d5d836b6ce63b63fd163d599e71d71fc30f0ef37f1"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3df8caad-2e73-4969-82d1-bd467054c552/06078adfbda938c50ab0dbca01f14ee4/dotnet-runtime-5.0.0-rc.2.20475.5-linux-x64.tar.gz",
+            "hash": "945d35b5e375a722fba6ae2986ef70bf1940ea3ccfe16f5e2211250354e2585ca4211589e0d14c127675c46c0e66df28046ce8f820ef7a71c9712c19c3f4c13d"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6e1df8ce-94d1-4fbf-b1fd-e7128696466f/0c0616999df20b12df4905075b00331c/dotnet-runtime-5.0.0-rc.2.20475.5-osx-x64.pkg",
+            "hash": "cfe08de2fc74e6b429954c215147e412f2ca54b80c7276c987e05eb11fb608c355765477e3d6d2ee728d20151496e5485f3c431ea8d4ecbc7ba03c9aaaaf38d3"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/71387715-de5a-4cba-851b-77bdcda1b8df/26fce295fd4e8c28e6cf2c50ca3aeb51/dotnet-runtime-5.0.0-rc.2.20475.5-osx-x64.tar.gz",
+            "hash": "cd5ae708568ce888d2a846a61aeb07a7ddba3b4eb5325476465c07b6be3853f4f085d46136e43c8eed1591931c3409df3cd4c09b358efafffd7f0c9977d18d90"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/123fb0d6-4c3e-4639-8cfd-155e3a6b1710/1b4c779d06b348cb440966c4998a80c9/dotnet-runtime-5.0.0-rc.2.20475.5-win-arm64.exe",
+            "hash": "fda592d6d227ed6a823e731546e4ffad9fae198a32e0f70b0830dfc600a572d95902c94f2ee110ff59d4265c04972e977663582b04f4119261c490d4c40ebc3e"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/49591300-4023-4a5f-9cc7-7bf46ec4fdcf/ea4caf85b4c3fb9adda55142ec66f172/dotnet-runtime-5.0.0-rc.2.20475.5-win-arm64.zip",
+            "hash": "3c85c0269ff67374b4fb3e1bdc5cc8ef5b100b4bc440860dc9c279211fb14139c1660fe2f2abdb311107f86ac6196c487b53d78523143dbb900efa23c40b7873"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/054458a0-ecae-4d40-8fab-cac711ab3074/79964cee73907a8a015db5efcb01ac3c/dotnet-runtime-5.0.0-rc.2.20475.5-win-x64.exe",
+            "hash": "2949b61cd69261b736625a7e3772a153f1d6f9e0fac2a10527d39ca77dcee50cd52fa03dd06fd40bc961e3acbee7e4f6038bc222697ff95fd42ca89986a4d889"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/603925fc-b50c-4657-a5dd-d1652aa39e07/90e27c1418a58bf3226cf6bab7dec5fa/dotnet-runtime-5.0.0-rc.2.20475.5-win-x64.zip",
+            "hash": "c30f33faacf5c2672339a29337984b7dbf64ba989a19396f9bb1858e5dfc4ce758787cae3c08580f864f30c491721d5a22a6f54ebd89deed1135b44181f901fe"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bd93b8cf-5757-49e0-93a0-ab53a377e5ff/728097b8d85670f3f64bddea4338d0aa/dotnet-runtime-5.0.0-rc.2.20475.5-win-x86.exe",
+            "hash": "fbe2633fadf447850db137bdbd8fd55efb2918314b3f74d1c677b2f096ef4fd2e112931d2b33822807071a55c1dc6ec4ef3f69f5f74c1f911f88db51d776e262"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a3b8f8fb-6824-4dac-a6be-dd3f51c487a0/e7a0ae5890d7731349acb1a39c730790/dotnet-runtime-5.0.0-rc.2.20475.5-win-x86.zip",
+            "hash": "aefde8e640b85a414e4624f81359df451bb7581cbc76098503df8f2ba1795274e16dd6687001f00bf7bf3c8acf01ba206556e5610bfe53513c4b639f9e3416b4"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-rc.2.20479.15",
+        "version-display": "5.0.100-rc.2",
+        "runtime-version": "5.0.0-rc.2.20475.5",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2019 (v16.8, Preview 4)",
+        "vs-mac-support": "",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/068ebc6e-4a1d-45ec-a766-733a142f2839/e0da4c731c943ca2b267c15edb565108/dotnet-sdk-5.0.100-rc.2.20479.15-linux-arm.tar.gz",
+            "hash": "22e97c15393a4f986563f5e8b031b49983eb55531170b86594d7caab819b41032393a9b3db4ee96cb88fae3971ba243bb64187606e3a00fc64d2e434d906a637"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b416bc12-1478-4241-bc31-6fe68f8b73b6/582f018a97172f4975973390cf3f58e7/dotnet-sdk-5.0.100-rc.2.20479.15-linux-arm64.tar.gz",
+            "hash": "1aab49b2c328c4de8c40e790df99aa327a3aeba5d904696fa151acbfb7b5620ebf3d1e2e9726895d92b6146295840ffe3f2fb7208a81c7b73d2c92c9fcf50dbf"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1ea8c954-015d-4ded-a221-6bcc27f53d06/c76bcb58b9a1539dcba34c0cb6c5df9b/dotnet-sdk-5.0.100-rc.2.20479.15-linux-musl-x64.tar.gz",
+            "hash": "1d44838a39810112e0c5b96ae8234e84f805ca4913888c18882ed7c0e291a7677672f593037a2dc94c6ad08c4d869394df72a4d42e0c668337df89327026aba1"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/69cb8922-7bb0-4d3a-aa92-8cb885fdd0a6/2fd4da9e026f661caf8db9c1602e7b2f/dotnet-sdk-5.0.100-rc.2.20479.15-linux-x64.tar.gz",
+            "hash": "e705043cdec53827695567eed021c76b100d77416f10cc18d4f5d02950f85bf9ccd7e2c22643f00a883e11b253fb8aa098e4dce008008a0796f913496f97e362"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/414d772d-9d3f-471b-8cc4-3badae3fc6f1/4324fbb212b8801c4b81723535b7e5d5/dotnet-sdk-5.0.100-rc.2.20479.15-osx-x64.pkg",
+            "hash": "53aec8d6486dd9f903ac59b68e711dbfc5eb4ad0250496098e96cbb2dce2a08244b61114faf1feeca6e343dbd510c16438852abbb693cc5a5d4db026bf17b3f9"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c0cafea0-6f76-407a-8c70-175c25e701d8/de9cc8367c469fa7eaaf5a7fb4aaf08d/dotnet-sdk-5.0.100-rc.2.20479.15-osx-x64.tar.gz",
+            "hash": "05a60dd57a0fc7a4d2cd517aff1c1685665009775a270e1e6ba2f632d24bd3439f026f4e287cbff4c22dd98f7713d8f34d785e3bbb73f6d0e530fd324b8c761d"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0940a90a-35de-40b3-b693-115d0aafb926/f15339d5d33a00fc5801be83e31433b3/dotnet-sdk-5.0.100-rc.2.20479.15-win-arm64.exe",
+            "hash": "fca159e140de6786b7290383356671424e2c15efa7b89b82826cbcb58c499fd3292dcb61f47aac026f57f93bdcd902309681b9aa434f16c3309d80e10ce300d3"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a5a30a34-0e4b-441d-8a16-4c6c356f418d/7369a30d2a2f04f2dac00f802bde3ae0/dotnet-sdk-5.0.100-rc.2.20479.15-win-arm64.zip",
+            "hash": "6d1488d2cc4f8bb2a935f5e0ff501bc21210c601d4ca0faac9dd603675b03cd71c20d15fea8ded88ac40b0ca0d3824a9097c98e05a3edebe53ba42b861efd9ee"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3121f13a-c4a7-4a93-bf87-f66f6a8b182d/f85dafe84e9d57d9f9c5c4e6a29d04db/dotnet-sdk-5.0.100-rc.2.20479.15-win-x64.exe",
+            "hash": "c9668250d1bd1017d1d847e380bd28eaa6b967cc952c1933e8978e9fbeaaf9b9edc24d48cb932296a8c1749999345b07d8167ab1430930732921c896ca2dc27f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5fc1edb6-c952-4071-88a7-3ff13c63ab54/71324a7c46138fa35d7f5921207d7142/dotnet-sdk-5.0.100-rc.2.20479.15-win-x64.zip",
+            "hash": "49ea4f9e0fdc51bfd46b1269b84dd09f26be957c3a81c80203a0b0d521c8ec190d0d2d631a4e1899c83b604bf9a529698f19eccdf4aed3d0fd2f89102f6556e1"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b39635bf-e274-4be0-b35c-a6f92875756c/805a41e904d14b70c3d64a416f5bf12f/dotnet-sdk-5.0.100-rc.2.20479.15-win-x86.exe",
+            "hash": "fd635f153c6bb4b1a4ed4839f50775dd3f4ec44dc6c3483b9640b1e2ae61c85051d52fcf774d815cb35260b35e11403ba7399520e6eda61442b64c16e4e9715b"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4503f532-215f-4300-b3b4-eb3ccd3c6ff3/79045e530ca8368c02ba9a2b764be28a/dotnet-sdk-5.0.100-rc.2.20479.15-win-x86.zip",
+            "hash": "44d25f3c304b50dfabf03b21246432fee397ce51948675e0b66032e5d87d61820134cff353ef05125ececb91f04d0ed8b7b049936adfd7eb6cd975a259bc51cd"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-rc.2.20479.15",
+          "version-display": "5.0.100-rc.2",
+          "runtime-version": "5.0.0-rc.2.20475.5",
+          "vs-version": "",
+          "vs-mac-version": "",
+          "vs-support": "Visual Studio 2019 (v16.8, Preview 4)",
+          "vs-mac-support": "",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/068ebc6e-4a1d-45ec-a766-733a142f2839/e0da4c731c943ca2b267c15edb565108/dotnet-sdk-5.0.100-rc.2.20479.15-linux-arm.tar.gz",
+              "hash": "22e97c15393a4f986563f5e8b031b49983eb55531170b86594d7caab819b41032393a9b3db4ee96cb88fae3971ba243bb64187606e3a00fc64d2e434d906a637"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/b416bc12-1478-4241-bc31-6fe68f8b73b6/582f018a97172f4975973390cf3f58e7/dotnet-sdk-5.0.100-rc.2.20479.15-linux-arm64.tar.gz",
+              "hash": "1aab49b2c328c4de8c40e790df99aa327a3aeba5d904696fa151acbfb7b5620ebf3d1e2e9726895d92b6146295840ffe3f2fb7208a81c7b73d2c92c9fcf50dbf"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/1ea8c954-015d-4ded-a221-6bcc27f53d06/c76bcb58b9a1539dcba34c0cb6c5df9b/dotnet-sdk-5.0.100-rc.2.20479.15-linux-musl-x64.tar.gz",
+              "hash": "1d44838a39810112e0c5b96ae8234e84f805ca4913888c18882ed7c0e291a7677672f593037a2dc94c6ad08c4d869394df72a4d42e0c668337df89327026aba1"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/69cb8922-7bb0-4d3a-aa92-8cb885fdd0a6/2fd4da9e026f661caf8db9c1602e7b2f/dotnet-sdk-5.0.100-rc.2.20479.15-linux-x64.tar.gz",
+              "hash": "e705043cdec53827695567eed021c76b100d77416f10cc18d4f5d02950f85bf9ccd7e2c22643f00a883e11b253fb8aa098e4dce008008a0796f913496f97e362"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/414d772d-9d3f-471b-8cc4-3badae3fc6f1/4324fbb212b8801c4b81723535b7e5d5/dotnet-sdk-5.0.100-rc.2.20479.15-osx-x64.pkg",
+              "hash": "53aec8d6486dd9f903ac59b68e711dbfc5eb4ad0250496098e96cbb2dce2a08244b61114faf1feeca6e343dbd510c16438852abbb693cc5a5d4db026bf17b3f9"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c0cafea0-6f76-407a-8c70-175c25e701d8/de9cc8367c469fa7eaaf5a7fb4aaf08d/dotnet-sdk-5.0.100-rc.2.20479.15-osx-x64.tar.gz",
+              "hash": "05a60dd57a0fc7a4d2cd517aff1c1685665009775a270e1e6ba2f632d24bd3439f026f4e287cbff4c22dd98f7713d8f34d785e3bbb73f6d0e530fd324b8c761d"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.exe",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0940a90a-35de-40b3-b693-115d0aafb926/f15339d5d33a00fc5801be83e31433b3/dotnet-sdk-5.0.100-rc.2.20479.15-win-arm64.exe",
+              "hash": "fca159e140de6786b7290383356671424e2c15efa7b89b82826cbcb58c499fd3292dcb61f47aac026f57f93bdcd902309681b9aa434f16c3309d80e10ce300d3"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a5a30a34-0e4b-441d-8a16-4c6c356f418d/7369a30d2a2f04f2dac00f802bde3ae0/dotnet-sdk-5.0.100-rc.2.20479.15-win-arm64.zip",
+              "hash": "6d1488d2cc4f8bb2a935f5e0ff501bc21210c601d4ca0faac9dd603675b03cd71c20d15fea8ded88ac40b0ca0d3824a9097c98e05a3edebe53ba42b861efd9ee"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3121f13a-c4a7-4a93-bf87-f66f6a8b182d/f85dafe84e9d57d9f9c5c4e6a29d04db/dotnet-sdk-5.0.100-rc.2.20479.15-win-x64.exe",
+              "hash": "c9668250d1bd1017d1d847e380bd28eaa6b967cc952c1933e8978e9fbeaaf9b9edc24d48cb932296a8c1749999345b07d8167ab1430930732921c896ca2dc27f"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5fc1edb6-c952-4071-88a7-3ff13c63ab54/71324a7c46138fa35d7f5921207d7142/dotnet-sdk-5.0.100-rc.2.20479.15-win-x64.zip",
+              "hash": "49ea4f9e0fdc51bfd46b1269b84dd09f26be957c3a81c80203a0b0d521c8ec190d0d2d631a4e1899c83b604bf9a529698f19eccdf4aed3d0fd2f89102f6556e1"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/b39635bf-e274-4be0-b35c-a6f92875756c/805a41e904d14b70c3d64a416f5bf12f/dotnet-sdk-5.0.100-rc.2.20479.15-win-x86.exe",
+              "hash": "fd635f153c6bb4b1a4ed4839f50775dd3f4ec44dc6c3483b9640b1e2ae61c85051d52fcf774d815cb35260b35e11403ba7399520e6eda61442b64c16e4e9715b"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/4503f532-215f-4300-b3b4-eb3ccd3c6ff3/79045e530ca8368c02ba9a2b764be28a/dotnet-sdk-5.0.100-rc.2.20479.15-win-x86.zip",
+              "hash": "44d25f3c304b50dfabf03b21246432fee397ce51948675e0b66032e5d87d61820134cff353ef05125ececb91f04d0ed8b7b049936adfd7eb6cd975a259bc51cd"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-rc.2.20475.17",
+        "version-display": "5.0.0-rc.2",
+        "version-aspnetcoremodule": [
+          "15.0.20270.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d28b2c72-92f7-44fd-b673-f7c24275f513/694228a9541d905bda4417156a9617df/aspnetcore-runtime-5.0.0-rc.2.20475.17-linux-arm.tar.gz",
+            "hash": "4e5b0babd454c321c67844a08111f7fd0fd1b594e61ee4b90b76fe05a51abfc8e0989758cf2b7260469e878f1911da22fd731db66dc65e53bcb74e3f82e35cbb"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/565b6b58-e67d-4572-b376-574634730f7d/46cd04ba8e137ad20fd0e97814350ff3/aspnetcore-runtime-5.0.0-rc.2.20475.17-linux-arm64.tar.gz",
+            "hash": "e3989a514d38efb4635beb745fbe383d89f7043d32272cd7760347a8d662013e1e2fcec6fc8f84c41f3421593c1922730c21829a8dc3b3246277c14fd8454305"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/265f6f53-9338-4b5e-b42f-923ce1bed379/d2959c292c1332765338097fc63cf686/aspnetcore-runtime-5.0.0-rc.2.20475.17-linux-musl-arm64.tar.gz",
+            "hash": "5f169b7497baa523cf6f7d1e8605619dc90886d7a9d5672d6226d77a9d003af3827481317c30992a0781972f78de191472a31bf10f58cdc81ee95b0d2b710099"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/37b5258c-1758-4e5d-8f53-7431199c1575/f6186fe70e60469e66ca1b1bc9f59ffa/aspnetcore-runtime-5.0.0-rc.2.20475.17-linux-musl-x64.tar.gz",
+            "hash": "35e85d3e822317a96dbba0aa239fe05e4f85e77031e3ba0c1fbd2a0800898bdaf377b800ab2a02510d2c0e0e6c51da1659b5afa919ebd0540fea2e02a8d7fa92"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76b700c1-f51b-454d-8082-dd0f6db0b5eb/e128bda60e4a72fd2fd38b50b442623e/aspnetcore-runtime-5.0.0-rc.2.20475.17-linux-x64.tar.gz",
+            "hash": "d60f0bd6218d00bb86eb0882fe0c823dbfca464d2647c01d0c8f128e9ca430c4d4fae47b3f961ac93115b0343300e58f8c81dec2f6dbe9f36accc5ea28d2cc7b"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4c32af7f-e685-4bd9-8792-e7cdd5f46a20/4bdad80338f3e4e4b65a04c5cd65cceb/aspnetcore-runtime-5.0.0-rc.2.20475.17-osx-x64.tar.gz",
+            "hash": "18860b6f3f7770373b3c95926a70021b94b785cb41d267e77e55c38e1a107aa7ade99b2d0df0e95c8e7cda552b2bb78cfd2b323eae9780af612a1329a4f4354d"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/36abe09b-b2ab-4986-9a45-87aa2391cdb3/07bd88dc9a1fc229faead6cf4eff92fe/aspnetcore-runtime-5.0.0-rc.2.20475.17-win-arm64.zip",
+            "hash": "2a89545112a619d9becf621a00bcc5ae32e7ad58fa41414dfbcccab4b58aa4548cd200dfe7f54210cac7e2cb3b589365488fc09a8726ec7ef5fd4f799a833257"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c29737de-627f-44be-ba9e-7292fb0fb97e/3476046d9f030ef6af11bcb7c4c51b7a/aspnetcore-runtime-5.0.0-rc.2.20475.17-win-x64.exe",
+            "hash": "0fb4c3c92a034340393e8b8296351530a7329b1e7f71673242c4003df75fb47dcce35029a613aac7dcdbea3f6a6a99198731862f94381f8fcdbac5a784e90b8c"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5208bb4a-0704-44c2-b8c1-95871f23f2c9/7c0c1fded168bb35ff4ddd5c3fb85736/aspnetcore-runtime-5.0.0-rc.2.20475.17-win-x64.zip",
+            "hash": "0085b9fa0580a3e35e7bed3fbcce313750abed3acc62a2d9a295d4f2fa144434ef5b47e352d43586bb48fe356c4f3eb4eccb0edb8dd3e6f763dbf7e50963ea73"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2306025-c7ad-45de-b351-0f04b30ac115/d75c53920c15dd23fc61d780722636ed/aspnetcore-runtime-5.0.0-rc.2.20475.17-win-x86.exe",
+            "hash": "7db366209c25b544345d0c65e63118748a739a411ddaa4403a7f192fc667fa0c3c7ce0103f41853c607965bcc8db2246c89d6e6fb0ec64a9beb3d2c1e2a040e7"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c79c6f94-e14f-4bc1-bdc3-527efa969faf/7e385dd3f773f925c89a93708d28d309/aspnetcore-runtime-5.0.0-rc.2.20475.17-win-x86.zip",
+            "hash": "503dc312b8c04472d18ac639351b9918f34bc27af968d88edff55c101103c2deccc622d9ddef5af504078e6af85c4b7de8dd83a799902f6726c37a6f3d6ab7a8"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/03f2261a-01cc-4a78-8505-88ba0457ef29/1ff22faa58152bec84e636e719c28528/dotnet-hosting-5.0.0-rc.2.20475.17-win.exe",
+            "hash": "49ac516fe6fa24bafcfb71be5fe8480d107c474a10bdd5d4da33c5d16e7e22bd42f9757f678ff8c681ccf82e579bcdda2edfd988a01e2c48940b21aaace86d6b",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-rc.2.20475.6",
+        "version-display": "5.0.0-rc.2",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a9243817-2e2f-4a9d-999e-41496c7681b2/f27e936a6dab4ab25f38616dbe7369e7/windowsdesktop-runtime-5.0.0-rc.2.20475.6-win-arm64.exe",
+            "hash": "94c958e7f6d30c032b7b4469f826f3ad77efe2c44ad9cf6aa8edc99dcd7eb860d348001ce4490346284383995b0aef96b66faf31b44fca0b35814bd0e1aae98d"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/91fb8d46-77fc-4d2b-9762-31584f514470/0c7041dfe359e909743f35e2585af108/windowsdesktop-runtime-5.0.0-rc.2.20475.6-win-x64.exe",
+            "hash": "e3f2c851a9793b11b3ce6c8454804111301ff2254268556c9b00610973b4580d2849e85cad91996a3dc98454f9cf63cee035f8c8da1cdbdcc3ee57b7222d3081"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f125aff4-8055-4ddb-955c-8e65043c33d0/5cc82db36244efb98176d2b4bfed584b/windowsdesktop-runtime-5.0.0-rc.2.20475.6-win-x86.exe",
+            "hash": "9bba9c7fe5e76509df6f6afc985ae4cb5d40fac7338fa12dc56388777bdeef21aaed3f178168025ea56549e55392257f12ac0a1cd4fb13654dc60271f4973844"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-09-14",
+      "release-version": "5.0.0-rc.1",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-rc.1.md",
+      "runtime": {
+        "version": "5.0.0-rc.1.20451.14",
+        "version-display": "5.0.0-rc.1",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/de043fe1-1a5b-4d29-878c-87a99efcca8d/8c928e7725179e4707975a13fc01d8ed/dotnet-runtime-5.0.0-rc.1.20451.14-linux-arm.tar.gz",
+            "hash": "5aab173d86f267f9a5b2ded5c9990c92c1f60ec512157390752f9f3ed5b64bdbd7ff9180db9398b09c2184bfb8ffb30fb1a54b8934fd81d11c15c53c1a06da7d"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/367623bd-affb-47ea-af65-466d6c002537/bae126bda0f016d1284402e73ab7d333/dotnet-runtime-5.0.0-rc.1.20451.14-linux-arm64.tar.gz",
+            "hash": "a03154f8a3e4a21685dc7f0d3d43bcd6bf7d590e67b2f232597cd360cd956261686c90cda0d871b4735fd2bdfee97b6e82828e41807091921c7cbee5f3720fd6"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/299d3d51-34fd-4a56-97f5-bc1b1e23c952/22ef5dc7fcb2093f28678192e38970f6/dotnet-runtime-5.0.0-rc.1.20451.14-linux-musl-arm64.tar.gz",
+            "hash": "81a1515131785746a92ccb5e592776b408f5c99c89d36828898efbd49b1fc88e56f77213d56b4f49fc69ab0eaa79931ff8f20c44b75be6ef71bf4281f49ac83f"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e61bcfc0-4874-4da7-9817-5fc538e2bddc/c7c43882804d9e46290629f2e433094a/dotnet-runtime-5.0.0-rc.1.20451.14-linux-musl-x64.tar.gz",
+            "hash": "a7a393d31e8cc27def0f74ee743de2cdec3f8f8ae27e542c4517815e83dae7f5715f806fb169e8675126023efffbbb28d46cedac2c727b2bd1f8419598d25716"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cac4993a-0f79-43c6-baf9-f688867a37bf/adf0935ca2082cd05d3f00adc04d1848/dotnet-runtime-5.0.0-rc.1.20451.14-linux-x64.tar.gz",
+            "hash": "c8f6c24029c2d3ef07ea1781a6aac4d51a46aeb33886091df038b76b49830272afe7ac97484e0372e2d3ce2e6c32ba842142f0d1194791922c08445d7ff4cc95"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/25bc26cc-515f-40b1-8d8e-a4e80be19bcd/f143b38c0c4e3fcfdaa2a10bff922409/dotnet-runtime-5.0.0-rc.1.20451.14-osx-x64.pkg",
+            "hash": "e67deaee44859432274fa71f4b7e99c884729f3e2fab89980f00ca7fb7d0ec1880e6d6ecdfcca29df575caa89540488395e77bd706ce85acace748cdfb6f251e"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/19a92536-8f11-4e76-8b66-1093944678f0/0c66d0d9559b252b81d665011b815b57/dotnet-runtime-5.0.0-rc.1.20451.14-osx-x64.tar.gz",
+            "hash": "c14a1e1e069a346fabf5a247a5b71b9bb5c4ea78c9ae81ae7bc0eed1bf17600d347cfb10c7208e2b05dfd7a7efb2dfe28497058b881758c95f27d863d90bba3a"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d5f01583-69a8-4077-aa86-50b11aece3da/a84a0a10fb1129c208e5da9d950204d7/dotnet-runtime-5.0.0-rc.1.20451.14-win-arm64.exe",
+            "hash": "2331ee31fe8d14fddf9fa2822b3959089944e57b3c8a5fee65472c2294f3b42c84d3b2a845b85b0c719ac9d6874d798327b62d6b2a2bea6540cd37efac9edc7b"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4d35ba16-337f-4ac3-9577-223bc4684fa6/c4e099b8f642a184f761c647c7b039ce/dotnet-runtime-5.0.0-rc.1.20451.14-win-arm64.zip",
+            "hash": "07dabeec549a7d18ccfc2b2ffab3f4d01427431822ff9ffd322824592c04094ce121613c560389efd546dae028c74c317986239572dcf31de653479f0110f7ff"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d35c675c-bc26-44c1-9c6f-f9d679a4c17f/e79d8bcb768e43b342a5020b56272038/dotnet-runtime-5.0.0-rc.1.20451.14-win-x64.exe",
+            "hash": "3ac337da864e1cde907484bb6ea26088ce9e1ce63fd3f0034e10f39337d5abf030a8bb2891c59b65695f1802aed3eb9c283ed5dad9e622ba98061e7e7f01ac1e"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d3423213-6348-4a57-b04b-5b68821ad58c/5e23fb7bf77de3239455a84f5ae1f41a/dotnet-runtime-5.0.0-rc.1.20451.14-win-x64.zip",
+            "hash": "7f21e60e173ef609b979550613a3d07ddf0541e59dcf2ac5f20270828142bb84c40ddeaae6177dd69888e8bc4c64642af5a8c3e3e7e037a79c526da2367cd180"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ff211b3d-28fe-4ed7-8da9-5302eccb8405/1eebf8abc162734815d9634a1ef48da8/dotnet-runtime-5.0.0-rc.1.20451.14-win-x86.exe",
+            "hash": "487F80AD3E8F40950E744965507B4D2913CDA2CA03B0F7C4046410EF2CAFC0D199A17CE1DA66338B14ADEA4550DFEC5EA72A95BB3E2423099A6253AE7D0C2EFE"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7d68f43e-bf7c-40f7-978f-d8c52a61c15b/0eb88cd6dce00eeb60879fdcc6d9a333/dotnet-runtime-5.0.0-rc.1.20451.14-win-x86.zip",
+            "hash": "8d1998a6222e5f570ddeda6bf1955c912b5dd591d69fae1d4cadcb0bf55cbf66958a4e727393bf5aa5a62d0a350cdbd9657fca48abbbd86b9b2dfe43d7740581"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-rc.1.20452.10",
+        "version-display": "5.0.100-rc.1",
+        "runtime-version": "5.0.0-rc.1.20451.14",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2019 (v16.8, Preview 3)",
+        "vs-mac-support": "",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e6456209-63c8-43fc-ba2d-11c43c9eacd5/3a12e6bae9ff57c1964eb83cb01604b6/dotnet-sdk-5.0.100-rc.1.20452.10-linux-arm.tar.gz",
+            "hash": "b0e6627497ced9d09fad9c48d266bd4cb94727dc254d8b4a79d445732669c14f5d9592a98c0452cb25ae5eb4f642373f544418e36873b33f0f3dd94f14003e26"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8f24c20f-cf36-44bb-9405-becc781e6a1c/b5d8a40cde8b4525ea65ac4e5c7250d5/dotnet-sdk-5.0.100-rc.1.20452.10-linux-arm64.tar.gz",
+            "hash": "2d04890c71e845d1eb08f5dfbbb9c93024d7a52fb1cc3fd50bd51bc6bd44e455c5c82abc8f04eef23bd012984ae5f86143c600ceb49c4c733935d95d5b68785f"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d30480ee-b9f5-4cfb-af6c-dfec2007c81d/51bdc68e5d97e8ca250118ae7865ba00/dotnet-sdk-5.0.100-rc.1.20452.10-linux-musl-x64.tar.gz",
+            "hash": "68481e880bf0d5a46eaa02d6498bbd3b98332afd275f15ef7925effb2b01ea8a89e73b268299eadcb3d64dc3df7095a1fded5d405fee96b9fb1b1b09a5883eb9"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e5536fae-e963-4fa6-a203-15604c7d703a/d0968c03feeeed41c2428854e13c0085/dotnet-sdk-5.0.100-rc.1.20452.10-linux-x64.tar.gz",
+            "hash": "d7e709dacc4bb188c2380060d24bfb5b791240dc33af8499fb4a31e1885a9377dad1d1ebc76847432ea67d5e4ac832a31679dc293e09fa6dade28f5fbbe4db9b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/288c8d33-c0e0-4ab2-a9c0-7278f4e2490f/68c2c7c6e1d971d29caa12302e9352cf/dotnet-sdk-5.0.100-rc.1.20452.10-osx-x64.pkg",
+            "hash": "44bd8fefaadd3142adf84ca7cf7e7fd34022a65c8f2ca5735794266ff68d9356bc3babbcdf90b8a36ee0b9aeb6ff9cd98791691bded646f07283cd20917981bd"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a9a2b64c-6488-46e7-a2dd-60910ea7819e/a0c754acda184512c3b192b7e7c94d73/dotnet-sdk-5.0.100-rc.1.20452.10-osx-x64.tar.gz",
+            "hash": "06bb40273071f3dd1e84ebf58abc7798795d5f1ac298f24bf7109d1597fd52ff31bcbf2b81f86d91d37ae293678d07f8da0469d7cbd318d19a8d718b6629dcac"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e0c5dd3b-471b-4605-8eaf-a84e0ed60445/fdbd3487fd325c7ec8c71acab3021a38/dotnet-sdk-5.0.100-rc.1.20452.10-win-arm64.zip",
+            "hash": "4a0340155583fafc5f67a761c0858f646dbe1f14c5c43377d1f8e625ec1a182994e4d6f9d831020426ab4aa777d5d854e793c31d3ea0884b2117d9af59f5cf00"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fc1e9923-c4ea-41eb-bddb-165b684fdd4d/cdc2508795eef111e2feb35625e2e460/dotnet-sdk-5.0.100-rc.1.20452.10-win-x64.exe",
+            "hash": "5631F81D9F06D0199FD32F3C98467DBB4AE59F6160C3EFA6B2BF572509F4178BE50DB9557BA89BD234758F01CF38A26BEF85D24D03E36B0571C47A4394E2EE4F"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/945cfab1-8db2-40c5-ae45-6abd84327dfb/81c57003fc6c33f4fa6e7fb7709c21c4/dotnet-sdk-5.0.100-rc.1.20452.10-win-x64.zip",
+            "hash": "299c1b232ba5a8bdcfd3b890816a3aad806cc22551f6a17554fd3a0220b2168af011431c191e2e33f9dd8a50194cdc207db5dd70708bef45b560af9eb0b20f5e"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ad6d35ac-f597-42d8-b0c4-48d685b94a33/bea99eb7c4e031191a9a88a50835a34b/dotnet-sdk-5.0.100-rc.1.20452.10-win-x86.exe",
+            "hash": "6e44fd1ecc91b568f625f85107157ee75d7d9db5a1489e7d18e40be9251ad27ca48345505bd4c0c58c41a9dc67e6b7c9d5bc5e0d46ad8d9ade14adf847c40dc7"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2b91e9b6-d651-4ff2-9554-55620a11ba15/43b32bd93c88e864aab23e6b9a22ff5a/dotnet-sdk-5.0.100-rc.1.20452.10-win-x86.zip",
+            "hash": "1609b77e47c8237661d2861222a1bbbd9f13f886bf6bfc40fc48e546ba3502ffd2ceebc1a0e03b614c8d744db08bcbf9c7f835f51dbecdb5e862306e913ad66a"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-rc.1.20452.10",
+          "version-display": "5.0.100-rc.1",
+          "runtime-version": "5.0.0-rc.1.20451.14",
+          "vs-version": "",
+          "vs-mac-version": "",
+          "vs-support": "Visual Studio 2019 (v16.8, Preview 3)",
+          "vs-mac-support": "",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/e6456209-63c8-43fc-ba2d-11c43c9eacd5/3a12e6bae9ff57c1964eb83cb01604b6/dotnet-sdk-5.0.100-rc.1.20452.10-linux-arm.tar.gz",
+              "hash": "b0e6627497ced9d09fad9c48d266bd4cb94727dc254d8b4a79d445732669c14f5d9592a98c0452cb25ae5eb4f642373f544418e36873b33f0f3dd94f14003e26"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/8f24c20f-cf36-44bb-9405-becc781e6a1c/b5d8a40cde8b4525ea65ac4e5c7250d5/dotnet-sdk-5.0.100-rc.1.20452.10-linux-arm64.tar.gz",
+              "hash": "2d04890c71e845d1eb08f5dfbbb9c93024d7a52fb1cc3fd50bd51bc6bd44e455c5c82abc8f04eef23bd012984ae5f86143c600ceb49c4c733935d95d5b68785f"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d30480ee-b9f5-4cfb-af6c-dfec2007c81d/51bdc68e5d97e8ca250118ae7865ba00/dotnet-sdk-5.0.100-rc.1.20452.10-linux-musl-x64.tar.gz",
+              "hash": "68481e880bf0d5a46eaa02d6498bbd3b98332afd275f15ef7925effb2b01ea8a89e73b268299eadcb3d64dc3df7095a1fded5d405fee96b9fb1b1b09a5883eb9"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/e5536fae-e963-4fa6-a203-15604c7d703a/d0968c03feeeed41c2428854e13c0085/dotnet-sdk-5.0.100-rc.1.20452.10-linux-x64.tar.gz",
+              "hash": "d7e709dacc4bb188c2380060d24bfb5b791240dc33af8499fb4a31e1885a9377dad1d1ebc76847432ea67d5e4ac832a31679dc293e09fa6dade28f5fbbe4db9b"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/288c8d33-c0e0-4ab2-a9c0-7278f4e2490f/68c2c7c6e1d971d29caa12302e9352cf/dotnet-sdk-5.0.100-rc.1.20452.10-osx-x64.pkg",
+              "hash": "44bd8fefaadd3142adf84ca7cf7e7fd34022a65c8f2ca5735794266ff68d9356bc3babbcdf90b8a36ee0b9aeb6ff9cd98791691bded646f07283cd20917981bd"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a9a2b64c-6488-46e7-a2dd-60910ea7819e/a0c754acda184512c3b192b7e7c94d73/dotnet-sdk-5.0.100-rc.1.20452.10-osx-x64.tar.gz",
+              "hash": "06bb40273071f3dd1e84ebf58abc7798795d5f1ac298f24bf7109d1597fd52ff31bcbf2b81f86d91d37ae293678d07f8da0469d7cbd318d19a8d718b6629dcac"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/e0c5dd3b-471b-4605-8eaf-a84e0ed60445/fdbd3487fd325c7ec8c71acab3021a38/dotnet-sdk-5.0.100-rc.1.20452.10-win-arm64.zip",
+              "hash": "4a0340155583fafc5f67a761c0858f646dbe1f14c5c43377d1f8e625ec1a182994e4d6f9d831020426ab4aa777d5d854e793c31d3ea0884b2117d9af59f5cf00"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/fc1e9923-c4ea-41eb-bddb-165b684fdd4d/cdc2508795eef111e2feb35625e2e460/dotnet-sdk-5.0.100-rc.1.20452.10-win-x64.exe",
+              "hash": "5631F81D9F06D0199FD32F3C98467DBB4AE59F6160C3EFA6B2BF572509F4178BE50DB9557BA89BD234758F01CF38A26BEF85D24D03E36B0571C47A4394E2EE4F"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/945cfab1-8db2-40c5-ae45-6abd84327dfb/81c57003fc6c33f4fa6e7fb7709c21c4/dotnet-sdk-5.0.100-rc.1.20452.10-win-x64.zip",
+              "hash": "299c1b232ba5a8bdcfd3b890816a3aad806cc22551f6a17554fd3a0220b2168af011431c191e2e33f9dd8a50194cdc207db5dd70708bef45b560af9eb0b20f5e"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ad6d35ac-f597-42d8-b0c4-48d685b94a33/bea99eb7c4e031191a9a88a50835a34b/dotnet-sdk-5.0.100-rc.1.20452.10-win-x86.exe",
+              "hash": "6e44fd1ecc91b568f625f85107157ee75d7d9db5a1489e7d18e40be9251ad27ca48345505bd4c0c58c41a9dc67e6b7c9d5bc5e0d46ad8d9ade14adf847c40dc7"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2b91e9b6-d651-4ff2-9554-55620a11ba15/43b32bd93c88e864aab23e6b9a22ff5a/dotnet-sdk-5.0.100-rc.1.20452.10-win-x86.zip",
+              "hash": "1609b77e47c8237661d2861222a1bbbd9f13f886bf6bfc40fc48e546ba3502ffd2ceebc1a0e03b614c8d744db08bcbf9c7f835f51dbecdb5e862306e913ad66a"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-rc.1.20451.17",
+        "version-display": "5.0.0-rc.1",
+        "version-aspnetcoremodule": [
+          "15.0.20246.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4f20eb4f-886c-44ba-aff4-c80356da3a53/e2933e72c3fdd65dd242f1260877a7f6/aspnetcore-runtime-5.0.0-rc.1.20451.17-linux-arm.tar.gz",
+            "hash": "dbbf0e8e9f96f8c9257d829534932416f13f54023d205b4b68eb04ed9a1a02985902631a43f2e45b063590a39b3a54f0f38b72fa66e023845b75614532a27343"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6e4ebb4a-9369-4140-a673-3d26e96662e7/75273b1fb5f1141e1b98008a0c1baaa5/aspnetcore-runtime-5.0.0-rc.1.20451.17-linux-arm64.tar.gz",
+            "hash": "0af8b2292f973ff6c2262f1d5bb2a7963a13bbd952528b931eaa1289b7c62625c896889b74885e55bea633f5f310617994c181a9a8f9cf2410a7de7b14ed80a3"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f3042e86-9bd0-43e4-9604-63566bb7c28e/7757edb49ee3a65b3cc9840c7ffe3c8c/aspnetcore-runtime-5.0.0-rc.1.20451.17-linux-musl-arm64.tar.gz",
+            "hash": "32a41290a049c891fcc52195be8f4e1f708a3a187ce5f3a811173a1b21433d8acadb7c69c926c4229a55f87598aac1e1ebc9ecf7a4a046c60273bdecbaad17d4"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cecfacdb-d286-46dd-8861-cd890a94b48c/1e3bb4a57ff116df1159073014a6b989/aspnetcore-runtime-5.0.0-rc.1.20451.17-linux-musl-x64.tar.gz",
+            "hash": "963ad9dbaa48e1224d53b7db3d8869de973e2d576368cb87ba95f3fafaa49cf36e1988eecaafe1e0efbd36f2cd3d9d171c39c5205ad93cdcdcf5a7c13860cef9"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/401a2d7e-e959-4517-93fb-94b9f3b43123/0eca99d7a04ecd47cc6ccfab78fcfdaa/aspnetcore-runtime-5.0.0-rc.1.20451.17-linux-x64.tar.gz",
+            "hash": "7fd22ab229dd8b17fb086334843ec6c5d2aa5e15bdbc7a101f14426b497edef6e209eba5b103fb54fa56e3d4077589c774cf7ef1796d0b7e209ab39d6688aaf5"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/38de39c3-20a6-4c57-b56a-8c1c08f59002/8dcdaa4f54c03fbee034471e01e685ed/aspnetcore-runtime-5.0.0-rc.1.20451.17-osx-x64.tar.gz",
+            "hash": "332c971b19aaca0fefdd3838d297edd4c4982f4a50ed80b87b2dcc0a16bd06d72b522118d0ea94739703c3d1d0692407c8ef1011caef6390718a701122ca35f3"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6c26756a-aee1-4db0-808f-9ea78618b3ed/e3a76f9beab8fc97791c43d038faee3f/aspnetcore-runtime-5.0.0-rc.1.20451.17-win-arm64.zip",
+            "hash": "df9480a488b2be74331074397da1df02c4e2fcecc71e648263aef867114ddbdfd5dce9d2a6986a188b9faa5d6a266757f2edabc48808d4846fa3d9dfc9efbec6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1b043251-286a-498a-ba8d-1cd402701d00/81184e7f41caace559f39e23c9ea4dc4/aspnetcore-runtime-5.0.0-rc.1.20451.17-win-x64.exe",
+            "hash": "6e86df24ac7db8741605c92eecd6e47a618bd41a40cfdd5cefa6f8f4d6b3fbf2a14f820d56cecbe1e0478b3c8dfa482847e88368280a0d3ca9eabe46a8d33d35"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d8a71a9f-cac2-4daf-b3d4-47a8c513ab8f/6b8e8040373ba16f2e42b80766429ed2/aspnetcore-runtime-5.0.0-rc.1.20451.17-win-x64.zip",
+            "hash": "f1c20497158c17541ffe07a4bc203e01ec14da71eaa70d69b184a2c10508ae5dfd2680d84f853c220a11c0ad35ddab6cca97b064e53aea43dd190138b95b57a6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/20f32578-040b-447f-8467-745f206836cb/54cad1c83ab689e31405848a36d4cf4c/aspnetcore-runtime-5.0.0-rc.1.20451.17-win-x86.exe",
+            "hash": "d77506b22f2b035a1d54c5388a11f3e9723cab7a119510047b170519a9c7da4a993681e0c42c40ce036428e1dd6ad76f3e33ea33aeac44784af3a5994a749606"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1d519a46-c43b-400d-ab16-c500897a4813/2b57eb77cbc34c98913242ceda883622/aspnetcore-runtime-5.0.0-rc.1.20451.17-win-x86.zip",
+            "hash": "e577dee573a25ed74380e2aa7e379623f46d6b6ca9cc1cbf45f32ef02a075b1363bb465444edb36e15f0ab54eec2444ddf155c6edb1962ecefde866f2052b8c1"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/014b34d9-d987-43de-9aef-d9498fe50457/c20af7937a2a870e05f371cc2fc29d23/dotnet-hosting-5.0.0-rc.1.20451.17-win.exe",
+            "hash": "db9850174d4780ea04319eafa219d916abb2ee124241ca756ce9a3937a966d1fbc14122629412973b73e6b5417288cc63dff7030fb7a00334e9b2ec607d70831",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-rc.1.20452.2",
+        "version-display": "5.0.0-rc.1",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/24b79158-2f90-4b99-b44a-da60a66c5e0b/9e34e2ba20915ea5b556a5d99404c757/windowsdesktop-runtime-5.0.0-rc.1.20452.2-win-arm64.exe",
+            "hash": "ae7d4ba20c42de38d1205a7deae0cb9f659631437eebc0fdce51de9e19d2d8dd32d09190ca64a635892deb4944fd10fcac7b6913a296f52693930b42973ec642"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/86b2d242-948a-43f1-8f6b-c2d13d6197f9/645e928a93bb4b8ecf3f2ee4611727eb/windowsdesktop-runtime-5.0.0-rc.1.20452.2-win-x64.exe",
+            "hash": "7814723aeada9ed2f0c5d1f5df3db2e8c34933d497e0d831fbedd5f58999d64d1d5300e370128e3a302f586538244aafe36646e8285a42bcad808a65e505d0be"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0d419c8f-8826-4ade-817f-95f34fdcd1fe/900952b5e8ce2c15e975373948608065/windowsdesktop-runtime-5.0.0-rc.1.20452.2-win-x86.exe",
+            "hash": "e74e8da2cf4d5ead67d43ba2d4ba21828e2694ae70ccd8c0bc02372089e4955f3b6cf129378751691ae52c97116b90ab546227109fd5cff68f00433ade05f259"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-08-25",
+      "release-version": "5.0.0-preview.8",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.8.md",
+      "runtime": {
+        "version": "5.0.0-preview.8.20407.11",
+        "version-display": "5.0.0-preview.8",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dd96b7db-9a23-4934-a9a4-27bb62dae2c7/c3f07938f86c503c64d96b8e160df90e/dotnet-runtime-5.0.0-preview.8.20407.11-linux-arm.tar.gz",
+            "hash": "16c5407f377d923b0fd06e116586225bf8ac108d8b81227bc515aecbffd7f780ff89fd05afaa637a2dd77d09992b6dcffc5b91584cde43a441d6d811ac3b1041"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eb3d8643-1c32-466d-a952-38a8f28293aa/9f652140193ca392a4b6fe5b7815378b/dotnet-runtime-5.0.0-preview.8.20407.11-linux-arm64.tar.gz",
+            "hash": "cf5becf396e6455358b1e662b722381a9f30125f23736e49f70b39b89d3a2b9c28f9632d2fa871cea6b2762e226dfa88f59b1ee41c9f620ea711a809fb3cd58a"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/703a3cdd-70b8-4377-8557-c78d71d9867b/bd17b82a0ee8471d213c1c988aaab480/dotnet-runtime-5.0.0-preview.8.20407.11-linux-musl-arm64.tar.gz",
+            "hash": "81d23a8d00203140356a29509335cf59ef00dc3062c663541c16f0d21db57f845195cc6012265903230ff91d9cd2c745c06e01a5adb77515f3f373d334f2aa27"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cf15922e-ea38-44fb-9b73-48e304c7cc48/d5748beb999b5c61d82ce0320c7d9633/dotnet-runtime-5.0.0-preview.8.20407.11-linux-musl-x64.tar.gz",
+            "hash": "fa301f0809a44f2ba6119ac2e39798ad004ed30bf92d1996ea848f50bf06fc9a18d53eaaf907c89690c763b8ab31cb300ff9bfc6dbf2fe115f77467ef788eb35"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6864f612-da49-4c51-aa2a-4f3a93c6ee46/c14cb76dd4987fb2e3c3f2e5a39c248f/dotnet-runtime-5.0.0-preview.8.20407.11-linux-x64.tar.gz",
+            "hash": "1b609d1bd928fc2015a7148c340d648f80f0e41d39284ac73a5a9e701425ec2c933958e3d9977e780866654876a7c7b3cb2af9f1ec1a426c6aed8538ab15925c"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/67249b40-ac76-4628-a5b7-e7086e4d1444/ab8ed91c5e9080d4a7bffcb8f901d89e/dotnet-runtime-5.0.0-preview.8.20407.11-osx-x64.pkg",
+            "hash": "d24e62a88591e82872fe253e84ddea4fdee61c6a48c6bc522e6146fe1164caf1adc18d5aee12b209f39ae909c93e46ab557e94c1d8ee20131e3e690cc49c7a7b"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a02df614-dade-463e-87ea-b9a0b4e91106/db80444ac5cd517af1ccb3d751355497/dotnet-runtime-5.0.0-preview.8.20407.11-osx-x64.tar.gz",
+            "hash": "c5d8c47bd3919c50641a3577a03b6364a620388d1f1e0ac2f1625c416781f13954dcd5db8f6d97b85ae1e9dc9ff16d83e6d9631cb0437f207af406e49ac5d498"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c55a26c5-c63c-4114-a047-246db8e5c173/595a39e08aae8749eb30cf530a222c49/dotnet-runtime-5.0.0-preview.8.20407.11-win-arm64.zip",
+            "hash": "04338fb73396688d0ae9c2ebb430a950b9c5410f7901111cda287397f71b0e322d5d20d76a5e2f48c1f49193a668eb67f7e6ec0794f4124977f2f513f0919a3c"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b33ef7d3-940e-49a4-aa17-481ef5fec237/e388c613c862840044c97fcc8d3e0883/dotnet-runtime-5.0.0-preview.8.20407.11-win-x64.exe",
+            "hash": "9a5d138b21f2485459c9aa5926698f4019c795cb6ff8b9cf847d00193fd93fb010ee64388ca44052bc02fe1dded722fa3a93f92606b78cf887afe7fd38a8a6f2"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3a6bf5fa-b454-496a-ad7a-92f12f0d04d5/f0ff7af8e59de4f069ff999fc5a57ed8/dotnet-runtime-5.0.0-preview.8.20407.11-win-x64.zip",
+            "hash": "c88c804428c3e91c825c4c88e2fa8097740bb359cfdca6906f34939dfa6f3111f3a4b4753d5584aeeb4ef4ff127eab62b05a0b758a59813945e18177730d8d80"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fb10c84c-067b-4cb3-b617-b68a6604a924/ece4ffdb5dd5f790faf3a086a544eca0/dotnet-runtime-5.0.0-preview.8.20407.11-win-x86.exe",
+            "hash": "7ebd5ac02a84a4e2523a62ed00a46c2ea4f70f4a9dce791e3b60ccbf9b04cf4f0986e2710af8e8df10dff51f1ad07eb2fb5c5b473dde0de0b604499cf7787b62"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/92fb7c7e-aafe-4d0e-a599-81776aa39caa/67445640cbc7a3723d2cade18965a191/dotnet-runtime-5.0.0-preview.8.20407.11-win-x86.zip",
+            "hash": "83a5b1f398031362a5097fd1806d742db3694e2afe6b679aa52e897417403ce523ac9c683bfade23e3093b33b6e7b34104371c400e66eeffe87b8d5e10590665"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.exe",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/64b526dc-ceb0-47c5-ae53-ca549152ad05/265f08c1f55b10540ce89aa8304a1106/dotnet-runtime-5.0.0-preview.8.20407.11-win-arm64.exe",
+            "hash": "83a5b1f398031362a5097fd1806d742db3694e2afe6b679aa52e897417403ce523ac9c683bfade23e3093b33b6e7b34104371c400e66eeffe87b8d5e10590665"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.8.20417.9",
+        "version-display": "5.0.100-preview.8",
+        "runtime-version": "5.0.0-preview.8.20407.11",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2019 (v16.8, Preview 2)",
+        "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/372de9c1-b63c-4df8-9250-00e107c1d6f7/ee94093420b5c001eaabecdb41621950/dotnet-sdk-5.0.100-preview.8.20417.9-linux-arm.tar.gz",
+            "hash": "d6ecc2b9d58deb758a5662b1f2234163375f5893f68a922bbff0764e8848c158867087733d4c1d7f056a9f3141200694c7bb7de5d3b044a89edaefa75e8416d5"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a1e93182-8026-4330-b78a-ee7d721107a2/003c59fc228a220df40d90d5ac434873/dotnet-sdk-5.0.100-preview.8.20417.9-linux-arm64.tar.gz",
+            "hash": "129e654636f84a23d486efb5064951128af6e691b3a00010a873721c28c9e88220e0f1e20b8c1c4515d36b018fabc1ec88cd496e6793d246c625198571b8b27e"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1e5f22cc-4ac9-4316-8fbc-5ff884140d02/6f8c3a67deb898fb7e6b3ac09dcff2b3/dotnet-sdk-5.0.100-preview.8.20417.9-linux-musl-x64.tar.gz",
+            "hash": "72f73241456c7dafa11dfa4611461a9d83903c8407f447f0a504da5a518063f5336fcf0efc1ba86f979373ea8eac20c75da5c05e4c992ffb8a5fcdc8f427bc00"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c58adb8a-49cf-466c-9b72-e4c51edae0e5/f915b953a5bfdafc300bd277d80c3513/dotnet-sdk-5.0.100-preview.8.20417.9-linux-x64.tar.gz",
+            "hash": "0d86c9c2663b635154238fe39fbe32b498a75102851017f27152dccd856e9a1ed48ae44cf1a2b19a5388ea3c4c3f8f2c01a35cd978e52d2350c060394b924a94"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6ff7a8f6-9e28-46bc-8d0d-f7fbc2c13a59/1c576dee55c50ce071c0b7bb504906aa/dotnet-sdk-5.0.100-preview.8.20417.9-osx-x64.pkg",
+            "hash": "d62fd95b984693f955882bfe6b86688590e3dd23d8d36d905aae90289a18a9c5ad0e3b406b1494acde1b53319260891f582bf22a96d72baca5921286b5c422a8"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/208507dd-a7ad-42df-a839-9c2b898e96ef/3be3fb4e5a5d388782a4d4a27b04caf1/dotnet-sdk-5.0.100-preview.8.20417.9-osx-x64.tar.gz",
+            "hash": "db916df98a5cfd0753554d70cd1e1af2f2e86b4df9e2ca4718c9d4ccd454dd043d233ee38351cd72f8da69da33b92f6c55f98111aaaaeb4b674bd804cb485618"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/83dda261-17c8-4343-8dbc-608480e48470/531c6e2a1e4428df35072b1ec0479331/dotnet-sdk-5.0.100-preview.8.20417.9-win-arm64.zip",
+            "hash": "e52d0cb02357c0256cf2a2f17bc49603ee7d779e9ba9ee05aa8b7fc4c92ea56dd1cf7eda297eab7fa1e9dc27bfbb45b47543b4080e133e9b9d3b757f64596d48"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/930818da-3e33-4a92-ab83-2cd67caa6bf2/1460af41e79907a1bd34f1243c3baa07/dotnet-sdk-5.0.100-preview.8.20417.9-win-x64.exe",
+            "hash": "1a28a02904108654adc5a7772347b65394793a9148b780aa358416dfcfdf13b9d2d20cce4bd7f99e9fb7689eeec4938aea20d99d7b7928150ab615860c603cf4"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/18f52997-a6a5-43a1-b68e-ea9a8017ab67/49f5c0939877b6be267865b99c022629/dotnet-sdk-5.0.100-preview.8.20417.9-win-x64.zip",
+            "hash": "dab0eb2c2aa29fc8d952e155a9f744e48f6155cb2dfbc1240ade40da22c882df299274a770d3d4002a8e22cb17a45b1aa63baa4edd7bfb70d41f8bbeee4a105d"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05bebc40-c289-4b71-8086-3d9ca76e838e/1b61d97f051f8e2e57f21c90e6f83efc/dotnet-sdk-5.0.100-preview.8.20417.9-win-x86.exe",
+            "hash": "b5976b76057c2dd99839e02e2b40633105503627d85083ec81648b04d2c6813888f2c895d92d29649eb09c983108d314b317664f220d0808d16b2d63cbb7f094"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/24f3d498-d7e7-4897-9f78-7e110bbaa566/8ad4588f7de049c949a106b2c1b28fc9/dotnet-sdk-5.0.100-preview.8.20417.9-win-x86.zip",
+            "hash": "c7dd10d1ffb8d8edd29e6ca34c1964202ddd8d151be3dd60a13d2d73409b9834ebf923119f43e7d4fcf6ffcb9a3a1149b1c8e2f20b302633d3102b392a8c784c"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.8.20417.9",
+          "version-display": "5.0.100-preview.8",
+          "runtime-version": "5.0.0-preview.8.20407.11",
+          "vs-version": "",
+          "vs-mac-version": "",
+          "vs-support": "Visual Studio 2019 (v16.8, Preview 2)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.8)",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/372de9c1-b63c-4df8-9250-00e107c1d6f7/ee94093420b5c001eaabecdb41621950/dotnet-sdk-5.0.100-preview.8.20417.9-linux-arm.tar.gz",
+              "hash": "d6ecc2b9d58deb758a5662b1f2234163375f5893f68a922bbff0764e8848c158867087733d4c1d7f056a9f3141200694c7bb7de5d3b044a89edaefa75e8416d5"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a1e93182-8026-4330-b78a-ee7d721107a2/003c59fc228a220df40d90d5ac434873/dotnet-sdk-5.0.100-preview.8.20417.9-linux-arm64.tar.gz",
+              "hash": "129e654636f84a23d486efb5064951128af6e691b3a00010a873721c28c9e88220e0f1e20b8c1c4515d36b018fabc1ec88cd496e6793d246c625198571b8b27e"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/1e5f22cc-4ac9-4316-8fbc-5ff884140d02/6f8c3a67deb898fb7e6b3ac09dcff2b3/dotnet-sdk-5.0.100-preview.8.20417.9-linux-musl-x64.tar.gz",
+              "hash": "72f73241456c7dafa11dfa4611461a9d83903c8407f447f0a504da5a518063f5336fcf0efc1ba86f979373ea8eac20c75da5c05e4c992ffb8a5fcdc8f427bc00"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c58adb8a-49cf-466c-9b72-e4c51edae0e5/f915b953a5bfdafc300bd277d80c3513/dotnet-sdk-5.0.100-preview.8.20417.9-linux-x64.tar.gz",
+              "hash": "0d86c9c2663b635154238fe39fbe32b498a75102851017f27152dccd856e9a1ed48ae44cf1a2b19a5388ea3c4c3f8f2c01a35cd978e52d2350c060394b924a94"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6ff7a8f6-9e28-46bc-8d0d-f7fbc2c13a59/1c576dee55c50ce071c0b7bb504906aa/dotnet-sdk-5.0.100-preview.8.20417.9-osx-x64.pkg",
+              "hash": "d62fd95b984693f955882bfe6b86688590e3dd23d8d36d905aae90289a18a9c5ad0e3b406b1494acde1b53319260891f582bf22a96d72baca5921286b5c422a8"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/208507dd-a7ad-42df-a839-9c2b898e96ef/3be3fb4e5a5d388782a4d4a27b04caf1/dotnet-sdk-5.0.100-preview.8.20417.9-osx-x64.tar.gz",
+              "hash": "db916df98a5cfd0753554d70cd1e1af2f2e86b4df9e2ca4718c9d4ccd454dd043d233ee38351cd72f8da69da33b92f6c55f98111aaaaeb4b674bd804cb485618"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/83dda261-17c8-4343-8dbc-608480e48470/531c6e2a1e4428df35072b1ec0479331/dotnet-sdk-5.0.100-preview.8.20417.9-win-arm64.zip",
+              "hash": "e52d0cb02357c0256cf2a2f17bc49603ee7d779e9ba9ee05aa8b7fc4c92ea56dd1cf7eda297eab7fa1e9dc27bfbb45b47543b4080e133e9b9d3b757f64596d48"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/930818da-3e33-4a92-ab83-2cd67caa6bf2/1460af41e79907a1bd34f1243c3baa07/dotnet-sdk-5.0.100-preview.8.20417.9-win-x64.exe",
+              "hash": "1a28a02904108654adc5a7772347b65394793a9148b780aa358416dfcfdf13b9d2d20cce4bd7f99e9fb7689eeec4938aea20d99d7b7928150ab615860c603cf4"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/18f52997-a6a5-43a1-b68e-ea9a8017ab67/49f5c0939877b6be267865b99c022629/dotnet-sdk-5.0.100-preview.8.20417.9-win-x64.zip",
+              "hash": "dab0eb2c2aa29fc8d952e155a9f744e48f6155cb2dfbc1240ade40da22c882df299274a770d3d4002a8e22cb17a45b1aa63baa4edd7bfb70d41f8bbeee4a105d"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/05bebc40-c289-4b71-8086-3d9ca76e838e/1b61d97f051f8e2e57f21c90e6f83efc/dotnet-sdk-5.0.100-preview.8.20417.9-win-x86.exe",
+              "hash": "b5976b76057c2dd99839e02e2b40633105503627d85083ec81648b04d2c6813888f2c895d92d29649eb09c983108d314b317664f220d0808d16b2d63cbb7f094"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/24f3d498-d7e7-4897-9f78-7e110bbaa566/8ad4588f7de049c949a106b2c1b28fc9/dotnet-sdk-5.0.100-preview.8.20417.9-win-x86.zip",
+              "hash": "c7dd10d1ffb8d8edd29e6ca34c1964202ddd8d151be3dd60a13d2d73409b9834ebf923119f43e7d4fcf6ffcb9a3a1149b1c8e2f20b302633d3102b392a8c784c"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.8.20414.8",
+        "version-display": "5.0.0-preview.8",
+        "version-aspnetcoremodule": [
+          "15.0.20228.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/af8c7d21-21bf-45ae-98c7-f64f4ac79976/b46d2c8a6fb630a9784a0eb73becdf24/aspnetcore-runtime-5.0.0-preview.8.20414.8-linux-arm.tar.gz",
+            "hash": "e64f2a609d34cdd27c402fc4e303c4ce8a6ecd243d9343f3c4dcc76110f17f8c2330b4627c0c2635c677ded8b360f62dfedbb364f2d0d977b318b55f09ef45b8"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bb7ac503-f0f4-42c2-a9f5-e8322da3b6cf/bec74f9c1bb581910a831ac206cb5bce/aspnetcore-runtime-5.0.0-preview.8.20414.8-linux-arm64.tar.gz",
+            "hash": "dc08a7992478d1ab4ac882290bc9877a8ce2f4e67649b856804b4b8e8d702789defd950a57398d0c94682b0f7a813e8dc984f42abb91924bf62410085fa15dee"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1de4e605-70a1-456d-9eb2-83a9c6f61a78/e03621a2ee9fa47e0c89319d6b72fbea/aspnetcore-runtime-5.0.0-preview.8.20414.8-linux-musl-arm64.tar.gz",
+            "hash": "0ddfe6891b2a9782e3a173bb2bd95126755a62df11af4ddd7aeefc113b53f4373fd33a6d87322fd0ece6a99370e6cf63efe0fede6eeb7e905208d12ff8a6ef04"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6aae0a92-a2e5-4d45-b340-6f36836dff3d/b97b3d4f0dbba122d5a134193eca5378/aspnetcore-runtime-5.0.0-preview.8.20414.8-linux-musl-x64.tar.gz",
+            "hash": "d1d4538373b353063cf3f7eaaea6a5aaada6c0b0fd20bbfdc34c38d0a1d0f4b5dabf559ec2add86aa4617122ec46fbdf8833b1b4e1de8df521b1d77dd484545e"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6ec7319a-d0dc-4f90-bded-414359f3dbbd/0a98f7527cd39441f82bea8c7ee375fc/aspnetcore-runtime-5.0.0-preview.8.20414.8-linux-x64.tar.gz",
+            "hash": "c32970cc75f337648c53c32c6c0ff1ef5b025ad3bc58ec23e5e931a4958fc8213fb5d8cb924664dc356aca782cea96066aad93b7f49ecb133ac7c00def01611e"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/528e0eec-3278-4b95-bdf5-51163ffcd4c5/1361ce99cc8b66bfb153cad731d13194/aspnetcore-runtime-5.0.0-preview.8.20414.8-osx-x64.tar.gz",
+            "hash": "1fa620a7375da978226cff7a077b8c43031204c819d3eea31cf75a9a96d7563a7d92f52a23b791ed679d97b4d3dbcd7a8d60f33efc42920f93df8da705fce301"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/531e5dd8-097d-4f73-8d34-f290731a1fe7/e8d5a2e8e84bfd92431d51cfadb48192/aspnetcore-runtime-5.0.0-preview.8.20414.8-win-arm64.zip",
+            "hash": "cfbc630320469eacf506aac019e9fd4a9e6646b14e32b6ccf207556d5cb29d37be240df98ed5b0f9afed975af34ab157a3d4f6cc47421797259586b844fa55bc"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/88269414-aea5-43e1-9cf5-a348c0e94ee6/6f20664fc34ce01399bf1f812a7868ac/aspnetcore-runtime-5.0.0-preview.8.20414.8-win-x64.exe",
+            "hash": "41da533bd2b9b3f5202247de65b5e7917785ade4ec27540aedebe777215af0f3f96d9b858333dd748be6738fcde9d91a925e38f941dc6762ee7afa93785c0ff9"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2780db17-a008-43c8-bb6d-d3839898360a/5c96823c59ced4784a2f66d61aca62d1/aspnetcore-runtime-5.0.0-preview.8.20414.8-win-x64.zip",
+            "hash": "63badf80f0faf78ed6d4667cf832df48961d6b970b01439d029c17dc6391ddd435e11cda4d26abafc2823ed7dce6a5545a7b07d0fabd60fb518208403c3f80a8"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/93116278-f49f-4117-9261-77cbc3007508/45c0a532c9c2a1f317db2d519808e36d/aspnetcore-runtime-5.0.0-preview.8.20414.8-win-x86.exe",
+            "hash": "2f97435c0fb5b04e45294c638554a57ac12e1000fd4cb73e502231fc0e309b9c1acec829e796c26b5030489c6f8406666d0a20f857bebaa611b1dd838f8b511b"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/605e68c5-31b5-4005-b198-54567bb25f5b/e8fd589883e65381fe3f3761acc47b8d/aspnetcore-runtime-5.0.0-preview.8.20414.8-win-x86.zip",
+            "hash": "52a1b25442330b044340d0f554da0fb63035d87f84262d77d63af95918381b4c466124aeb5a255fe34ba2bbd77523366e86892910ba749c51c54674cb2af69da"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f640ee74-e5af-431b-8066-0df709f9a0f9/30e5f79144a2476eb64ccfa819f86e5d/dotnet-hosting-5.0.0-preview.8.20414.8-win.exe",
+            "hash": "d6605ed3b498863e8fea05b132870c1840dd66324b6b89ab7b347babb034de10ba87a8adcf0ef2246463f17afbead2de1148fea7aa585581bc844d01f94ee323",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.8.20411.6",
+        "version-display": "5.0.0-preview.8",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/85c2e2be-5ff3-4cb6-8d2d-f84f6f9d11a1/6fbc1e4588061acfe7243cc806207a4e/windowsdesktop-runtime-5.0.0-preview.8.20411.6-win-x64.exe",
+            "hash": "ebf8593f71ac130df9e2f67ee5aa2edc5e347f2fc65f200e1951c72f1f065ec6e69104f207e1d22b96e28afb2bb1ac99ec00860071caf6c1ed2093e7e578b4cb"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/04031d30-58c9-46b2-b0b6-3a6eadfe3123/589021a196f64f67b2a7de709ce65cb6/windowsdesktop-runtime-5.0.0-preview.8.20411.6-win-x86.exe",
+            "hash": "caf9e40055f0f97d7f90888c8b980b4386fdc4a482ab20a6384fede3c56f9aca88a74aa9ce4d24cdb11b9b0e5c2b0868a12cf58fb74eafe660b33e735420af16"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-07-21",
+      "release-version": "5.0.0-preview.7",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.7.md",
+      "runtime": {
+        "version": "5.0.0-preview.7.20364.11",
+        "version-display": "5.0.0-preview.7",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a11aa133-be76-4120-baaa-10be1e7eb4a2/55f000bd8967476e3e7dc24a4ba6c692/dotnet-runtime-5.0.0-preview.7.20364.11-linux-arm.tar.gz",
+            "hash": "1d65f3e708da676c5b9295048af240143c7efdb34dfe616edf50fbcaea3747bb4607afb5af5dfda664a512004ad3c31aeae4c142cda3d06ef51ade1832655bd6"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/79fe08db-0239-49c3-a733-d66a61b90a46/9e20b794946c31f310578d0ffc71c5e0/dotnet-runtime-5.0.0-preview.7.20364.11-linux-arm64.tar.gz",
+            "hash": "ea62c09ce3de2732dc94c3384dc7c6ae580703b671dd2670b53a587603c778ba5d399544d3a5c8cbcaad95f4bdc4cad905776247000265bbc6a6ee647f83a96a"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/174bc11f-ed96-4bc9-9bf0-4ff0a5b95279/1d3cc202997876f2602afad1d9745b18/dotnet-runtime-5.0.0-preview.7.20364.11-linux-musl-arm64.tar.gz",
+            "hash": "813b804b3a88aaee78b887e565b05c34e9c9aa3d2dd99f9265caa10639a3f53c999df0f6e3260ddd8c4784cb9fb8b1f1aa4bd1754978570ffba778108dffd10f"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/887d0415-ea76-4b39-9b9a-1bfd81cd49e4/118d1385ff15daf9644ca3c164de5814/dotnet-runtime-5.0.0-preview.7.20364.11-linux-musl-x64.tar.gz",
+            "hash": "8b68b7601ceddbc513272b3c80ba2439046b397e96ffaa07b24efcc5bb32c7854f5a4f851c4f08cc9201167d07f17427e750a51d7392cf2eb9f6e4d0fbbb41b7"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/50405a40-62b0-496f-a099-a1a4aaf7e8a1/8162d7f1eef3a9100160d2e275fe4363/dotnet-runtime-5.0.0-preview.7.20364.11-linux-x64.tar.gz",
+            "hash": "409802189c72820e67a5b064b8f2997095bc5b0be7a4c6734473c6aa56220ff60c758e4c12d2e99e2cf93cf8510e9bbe66e26e68abbe85085c28c5bc9428e77f"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0c69d2c6-b205-49df-b23a-7bff3843b75f/ab032df86acfdf39ec240a91fb316ce8/dotnet-runtime-5.0.0-preview.7.20364.11-osx-x64.pkg",
+            "hash": "5b28d31df77416b44450dd057aed57e1a6d54ab0504c330608c3c305b100f631aa188636757f054154b1a4d30ad74ee0b7bf514fa95c856d8ab438fda6f26dca"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/54247350-9123-4c9a-86e9-a06c766de011/6a32bb36fa5dfc062fcab8c162c2bcdc/dotnet-runtime-5.0.0-preview.7.20364.11-osx-x64.tar.gz",
+            "hash": "867d9a30010dc8513427b24d50530a26b87ff68db68054cb01181b4d3c46c27479304cdddb005d75c8a998d5bbc7880a06dfc05a1375793ad474df52a614ca2a"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f63ca84d-31c8-4b0d-9234-950c8a74f7cc/8f053a507356f3dbde2873c53f6752d0/dotnet-runtime-5.0.0-preview.7.20364.11-win-arm64.zip",
+            "hash": "1dcf95be852426bef33920b6a61052b560a18a229da56e6df8eceec01d41771342ece153d96a07a59cc64f88b566dc4879eab8cb136fcac79f56ba14b8f63960"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/203aff04-57b2-4183-9d24-daf502fb9599/cf85a20cc0de18dd31f199c8f8528601/dotnet-runtime-5.0.0-preview.7.20364.11-win-x64.exe",
+            "hash": "b849e082dbf15ec0c5058e1a2fff96ad825ad60fa35f5fc1c263f63968f739d047e59742086f7c63d3fb83fe56681820cc99689237f13b49d4168b5ed103406d"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1f275906-3b32-4a81-9468-a6b47d846130/5cea07ee6b9dcdf2d753c4a9767b4b95/dotnet-runtime-5.0.0-preview.7.20364.11-win-x64.zip",
+            "hash": "f4769be164dd465b957db9308a5478f5089f8d8736b08940ce9a09c5adcf03734ad5ba8dace9b5ca85604665afa0c20c5563a7ed5fc97bcc7c18971206bbe4c7"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2db260ef-40ba-4cce-8666-7de8b879e9a9/a4f4a0671b4e8899c217354e9d8371a8/dotnet-runtime-5.0.0-preview.7.20364.11-win-x86.exe",
+            "hash": "60c5f049bb444a1f364f03d6d166bbc5a8fe47cfad44bb48b5861c473dc78a9d03ccdcd3fd8b31971a86217d8182b12b094949f2dfe876bd2b087b94cde3e1e1"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0e451052-dc35-4b5f-827c-22bfdaa1897e/be0d5cbf43d0ef055899cfec4082b835/dotnet-runtime-5.0.0-preview.7.20364.11-win-x86.zip",
+            "hash": "963a1728dd579104272d2b0b5bb906fa5252a4c11861cea676c9306661d9a27ec25709a8d8d714bbe0806f344725aa5c9d51dc00dd2d9d8b854a7902e9d52568"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.7.20366.6",
+        "version-display": "5.0.100-preview.7",
+        "runtime-version": "5.0.0-preview.7.20364.11",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2019 (v16.7, Preview 1)",
+        "vs-mac-support": "Visual Studio 2019 for Mac (v8.7 preview)",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/20349622-b776-4fa0-a981-adacd7d57b9c/174f26a811b61a11a2132613e27f442a/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm.tar.gz",
+            "hash": "2e473ba7d2ed706313a02438da2b338fa91785cbbd68d1c15268641b3d547b7183e9f5be02df8f6d2af537e02280dae94cee63a4d3dd42bfbfb3cb4ce5fade59"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a7d933ce-5f1d-4c7b-a388-509ee6ee710c/152fa9acb7ee9cf34d7cb0eeeb36d448/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm64.tar.gz",
+            "hash": "34cc65a879c8dedf854e0bb5b8b3f415c7db1ea9281a868516b6c0fdbb6d356dbd41ca258c10aec0c33339a5bc3be6cdf4e4d96099b6e3f73abb841e9c8d2dae"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30b3cc30-0985-4b87-a7fc-b285bc7798b7/18c6f1b429f4e315d9ce1839191031be/dotnet-sdk-5.0.100-preview.7.20366.6-linux-musl-x64.tar.gz",
+            "hash": "5dc8a07ed8964ed88588b7310ecaeb75be711604334ce6d06b6a6400a28780cbb92264a5022a7acf4b6dbf18c08110a263309dd3adfef3dd1aa20eebbe9ac959"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6e9bdda1-72b5-4d2e-8908-be9321b8db26/cbc8ab6c3a1aca2a8dd92e272edd3293/dotnet-sdk-5.0.100-preview.7.20366.6-linux-x64.tar.gz",
+            "hash": "a1369d4e9e6281a3656acf6ba8357fbb9b25824fa63b42b55700f4d7ab58b2dc355b91c356a13c7d76da92e30dd3a5ccefd1d3396eacc1ac62cbae608b5eed86"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7a2f569c-f3be-43f7-8f5d-ccc2b62b06ca/a7f72e40a5ee418cd15fa477d30d4b30/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.pkg",
+            "hash": "fbfaf8900fa35e4656a92981a2d14a578756a2b6fc6ec747d4460be316c6fe07efffeb1f842126b37111404a70f2c43aa516f97494a66b49801710553a62c917"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76749af6-cccc-430b-91e6-f2beee11d922/4b4594efa029d19c864187820f0a7f97/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.tar.gz",
+            "hash": "eed62702c03a3011ccb534f75d4986d09948cf64d601c083759e6770f549cf159bb9adff9c34865e1caa15179f484d22772a4ca79c591823b1ac26025472bf35"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7c9db83f-13ea-4246-a69d-a51a4e4113ca/5b3ab7f5667fe5bb7b00c9484cada3e2/dotnet-sdk-5.0.100-preview.7.20366.6-win-arm64.zip",
+            "hash": "2c4bee81067deabb53f37935096e81483584f3b634a176824366a647ed1271b307a11ff34f3b0b280c7e2e19c12c4d1d3a37d19c87a51611348fbb04f48733ae"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/21511476-7a5b-4bfe-b96e-3d9ebc1f01ab/f2cf00c22fcd52e96dfee7d18e47c343/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.exe",
+            "hash": "93400774be604fa238d86fbbbd52eb8488eab317085c6864cdc730e9ea572be46691fa633c5f46bcbe8f7245c5ca722fe23e5d43f654c6d7781cdd292cd2af97"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2febae4a-9ac0-45ea-bf2f-adbe75492a94/d0bee7791c904c5c33bf25b12556aa34/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.zip",
+            "hash": "a77458590193d71f4c7f483b765fc16495fbb9a83f79cfb943ce46a67c3e9049eef7da87398d8637a4f547cb57a64857584b2b43009593d24daea9f5af6d31cc"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d536432-9be1-4193-9fec-9e920663e0d0/4b01d64266b503a320e92072e529033f/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.exe",
+            "hash": "d505ad12efc18d0a09ccb484136f9aeddde06a85caa37822a81aade1bb8f5b42369cdb4dfe67d62c197cc623383f5566f06be89e06ff5e8e4fdd1db96a4a02b3"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/add0a0a6-088d-4c79-ba7d-199e6fb44f3a/560013573bf4f46bfbdefcb7d770a397/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.zip",
+            "hash": "eba7c98457d91fecdcd303961866033415631f28088ebd3b43e49c2356aab89b77709c144a8c28939d53edeaab8bf26c9681de79e9df7fb73350f4b92529f497"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.7.20366.6",
+          "version-display": "5.0.100-preview.7",
+          "runtime-version": "5.0.0-preview.7.20364.11",
+          "vs-version": "",
+          "vs-mac-version": "",
+          "vs-support": "Visual Studio 2019 (v16.7, Preview 1)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.7 preview)",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/20349622-b776-4fa0-a981-adacd7d57b9c/174f26a811b61a11a2132613e27f442a/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm.tar.gz",
+              "hash": "2e473ba7d2ed706313a02438da2b338fa91785cbbd68d1c15268641b3d547b7183e9f5be02df8f6d2af537e02280dae94cee63a4d3dd42bfbfb3cb4ce5fade59"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a7d933ce-5f1d-4c7b-a388-509ee6ee710c/152fa9acb7ee9cf34d7cb0eeeb36d448/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm64.tar.gz",
+              "hash": "34cc65a879c8dedf854e0bb5b8b3f415c7db1ea9281a868516b6c0fdbb6d356dbd41ca258c10aec0c33339a5bc3be6cdf4e4d96099b6e3f73abb841e9c8d2dae"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/30b3cc30-0985-4b87-a7fc-b285bc7798b7/18c6f1b429f4e315d9ce1839191031be/dotnet-sdk-5.0.100-preview.7.20366.6-linux-musl-x64.tar.gz",
+              "hash": "5dc8a07ed8964ed88588b7310ecaeb75be711604334ce6d06b6a6400a28780cbb92264a5022a7acf4b6dbf18c08110a263309dd3adfef3dd1aa20eebbe9ac959"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6e9bdda1-72b5-4d2e-8908-be9321b8db26/cbc8ab6c3a1aca2a8dd92e272edd3293/dotnet-sdk-5.0.100-preview.7.20366.6-linux-x64.tar.gz",
+              "hash": "a1369d4e9e6281a3656acf6ba8357fbb9b25824fa63b42b55700f4d7ab58b2dc355b91c356a13c7d76da92e30dd3a5ccefd1d3396eacc1ac62cbae608b5eed86"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7a2f569c-f3be-43f7-8f5d-ccc2b62b06ca/a7f72e40a5ee418cd15fa477d30d4b30/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.pkg",
+              "hash": "fbfaf8900fa35e4656a92981a2d14a578756a2b6fc6ec747d4460be316c6fe07efffeb1f842126b37111404a70f2c43aa516f97494a66b49801710553a62c917"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/76749af6-cccc-430b-91e6-f2beee11d922/4b4594efa029d19c864187820f0a7f97/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.tar.gz",
+              "hash": "eed62702c03a3011ccb534f75d4986d09948cf64d601c083759e6770f549cf159bb9adff9c34865e1caa15179f484d22772a4ca79c591823b1ac26025472bf35"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7c9db83f-13ea-4246-a69d-a51a4e4113ca/5b3ab7f5667fe5bb7b00c9484cada3e2/dotnet-sdk-5.0.100-preview.7.20366.6-win-arm64.zip",
+              "hash": "2c4bee81067deabb53f37935096e81483584f3b634a176824366a647ed1271b307a11ff34f3b0b280c7e2e19c12c4d1d3a37d19c87a51611348fbb04f48733ae"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/21511476-7a5b-4bfe-b96e-3d9ebc1f01ab/f2cf00c22fcd52e96dfee7d18e47c343/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.exe",
+              "hash": "93400774be604fa238d86fbbbd52eb8488eab317085c6864cdc730e9ea572be46691fa633c5f46bcbe8f7245c5ca722fe23e5d43f654c6d7781cdd292cd2af97"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2febae4a-9ac0-45ea-bf2f-adbe75492a94/d0bee7791c904c5c33bf25b12556aa34/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.zip",
+              "hash": "a77458590193d71f4c7f483b765fc16495fbb9a83f79cfb943ce46a67c3e9049eef7da87398d8637a4f547cb57a64857584b2b43009593d24daea9f5af6d31cc"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5d536432-9be1-4193-9fec-9e920663e0d0/4b01d64266b503a320e92072e529033f/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.exe",
+              "hash": "d505ad12efc18d0a09ccb484136f9aeddde06a85caa37822a81aade1bb8f5b42369cdb4dfe67d62c197cc623383f5566f06be89e06ff5e8e4fdd1db96a4a02b3"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/add0a0a6-088d-4c79-ba7d-199e6fb44f3a/560013573bf4f46bfbdefcb7d770a397/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.zip",
+              "hash": "eba7c98457d91fecdcd303961866033415631f28088ebd3b43e49c2356aab89b77709c144a8c28939d53edeaab8bf26c9681de79e9df7fb73350f4b92529f497"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.7.20365.19",
+        "version-display": "5.0.0-preview.7",
+        "version-aspnetcoremodule": [
+          "15.0.20198.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f114ff73-807d-47b9-97f7-51b0e156a5e1/58eac9a7e3bc1b3df4fc0fe63ab05846/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-arm.tar.gz",
+            "hash": "22862455eeb0061c2f7e2e976149be3f5e037128f226e0f1e080b5c75af84a45549e201dddc17a226994b460b8c243d401e0351f8bd7e5b48a6bd74c220b1c42"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/137efdf7-85d5-47b2-abf5-24ffd0aab3df/01e445249ffec368b655afb4caf1d7d7/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-arm64.tar.gz",
+            "hash": "8b153075d62e3cbeb0878f4af0dee2e8fd76888a17ff02ece60b98905c69f057236e8c9aa6e99d512f2e256513e111ecb1acbbf42d48c949e21c60d744812694"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/50f7778e-c753-4d25-9195-4a47fd5bcbbf/670d67d27e9206e41a537d2850f49b66/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-musl-arm64.tar.gz",
+            "hash": "733d5ed7fd90eca31a85980dc64d1298a89d17157323b7eacc79e0e83592235de68b083ce03cf280608233fc3a5b6a27e8d52516ae543bf29d2d0258a3e156f9"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9707011f-6c4d-435d-9fd0-18f1d0048bfa/a7781a25cc2b5088d6439523f2c07f23/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-musl-x64.tar.gz",
+            "hash": "ff63042916c597820fa93eac34a6c0d889b9498aae554067010a94af367b8291f59fcd0832227274bb864209de486ba1cff87967388147b6f9433be1b5ce0953"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/623a385b-1bb8-4e4a-a677-eaa41e956f48/82b58a95fc101d3455db376c339e169f/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-x64.tar.gz",
+            "hash": "6a6bbe7848e835b6dbfc183eb30dad2f88aed5b7a4509584b5309bab5ef6f6f0b5fc4b09d7b557ca4e30b31a93a6583dbe904c185772b8bff58d3d4d7134053e"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/49fb6ead-64b0-4cfa-baf5-060b178bfe18/32ee2fdd5fcd1916095c376c0806dce0/aspnetcore-runtime-5.0.0-preview.7.20365.19-osx-x64.tar.gz",
+            "hash": "12f41424c67b0fa557a214a6a21de6aedee8734b9a622ccc83c2093dce16dc1e7919242ec60ced50aa3695bc2330623ccf41c813426f04d742aec89ecd4012fe"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c9e68175-6c43-4fe3-82b4-135a0e85ed8b/d4865f422f061e03822b6011350d1bcc/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-arm64.zip",
+            "hash": "e0bc8c07fcdca781ba6bf6783b4d6db5151883bc3be11a3fddaaa8a7a752732c04cf938c8a36a494cb7b0c9c517755eb350b36bee2671d8d8045ea8925a2c0b6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9d2b759f-1bbb-4b00-a1b9-4b191c074254/cf51d83f10a4dd9327edd7a238cde6ec/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x64.exe",
+            "hash": "27795c11defee0ec1d3ca531e05a42e0369f8129cdbc9965c2f2f9dfd0173f58260b88a812677917f656395f2170541e7d6dc9ee99fb0d84126c9e1da9299d50"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a0f2fca4-a2bf-4657-834c-be0dec09f04d/27553adf1b80316e194510099830ed20/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x64.zip",
+            "hash": "2d50901aa5329a00ed339b8bd683a0bfdf115bb6f9bc3b29f408e72c99a27c530812939e37ec467eb5f7756be6153bb314a9e13e10788dcb4d3a3b1377a1a73c"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e0f0dd65-4db3-4ea9-8ddc-0296e290b93f/23faf5910857010dd62dc0233c59fc79/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x86.exe",
+            "hash": "dfbad08ed65fe4c9b6c098c4455b88ad12e6cf3cab242b4fef0d6f07c09f007385b51ef37741ff6e4c2a21e23503629641c30485cfb52fe2c29c957e83f17bcd"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7deab25e-7e72-49d0-95c9-976ebf929590/560cfb70f894fc6ca3ea3c34ef4b3404/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x86.zip",
+            "hash": "49d153656f367287b2763b74782fbec96a4391da067a6533d44b3ff204aec76cda3b723ce847af3be8f9be1f61b84e06a70ca8f5dc663f0c36b3380f703d223a"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2fd2cadc-2068-4055-b269-13cf1d06083c/86ef0372321ed82efc7230aa41ebd3db/dotnet-hosting-5.0.0-preview.7.20365.19-win.exe",
+            "hash": "8ab6111bf8e4905189ea69a72bd295e1fa6a14627d213f88f35885e71022d336ca544c4bffaf8c0a954b6240b8a9e61483e24294553477b13c112c4a5aafe71a",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.7.20366.1",
+        "version-display": "5.0.0-preview.7",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b1ad0793-f281-4574-b672-09ac4bd6ff9c/303e98093e01e9b10a425d58b26bb601/windowsdesktop-runtime-5.0.0-preview.7.20366.1-win-x64.exe",
+            "hash": "31bb3a26fed1ff39afc5308a52350bfb3a1bdb5d3a8cac33628ccbd8dd22291b193fcde79a76d8cd3bf69f4e58b3e53716b63fd8434b8ecfeb0e7d7ca3e3bbb3"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d12f1c16-2d25-4a7f-a3cb-cf839b07526a/b9ac0cb450e8563a2272510a379511fc/windowsdesktop-runtime-5.0.0-preview.7.20366.1-win-x86.exe",
+            "hash": "cc464d76b8922ba8f8e5e97475f05b01123952e8410d3f8a7a417c5bc35cfbf60e984a760e8687dc72f40fe545ed24bc6e346bb7a9cd144393022f8de2e71dea"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-06-25",
+      "release-version": "5.0.0-preview.6",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.6.md",
+      "runtime": {
+        "version": "5.0.0-preview.6.20305.6",
+        "version-display": "5.0.0-preview.6",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c193dbd4-612f-4185-bd89-c79f2c7a57ec/89e9c35b2949436d25df6536f82fba48/dotnet-runtime-5.0.0-preview.6.20305.6-linux-arm.tar.gz",
+            "hash": "7e9a70a13ccd56d282e336beb57e7714c4cc8dadf88cdc77c15be91eb3a24c10742651f07960aacd1ff84402120f7e75652403b2e00db2c5011634a30fcf5811"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/032c7427-1de9-4127-ad97-c2aeb927fe1a/00475ef07e0ee12a161221d1cbe3b5a6/dotnet-runtime-5.0.0-preview.6.20305.6-linux-arm64.tar.gz",
+            "hash": "0890f5e1f54d38a8e4cd99637eb9155da663ae4b466bf56fc36bb9100c688201d814547400859614e41c4946ff05e789a87575ecbe1f15e63b578c8ef4d765ce"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a913f6ee-16ad-493e-bf75-59d2d48de3f1/4105f0f967d03dfc2cdba711323e60cb/dotnet-runtime-5.0.0-preview.6.20305.6-linux-musl-arm64.tar.gz",
+            "hash": "0db9e2b02d42557854d080dad21f027e2967ee2fd0c6a368952526e6b8af1c3f1768d99a642802166201b40ab084a4040588993b6231d65b6edba8e068ae9f72"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f5645d58-d3bf-40b9-9150-400604b3ad36/2a5de2de91b15018ff0ca0f79db1046c/dotnet-runtime-5.0.0-preview.6.20305.6-linux-musl-x64.tar.gz",
+            "hash": "416eeebfd90d66f68cb6e68842b3b89c080adf4a4773d3af822d1cdc4469c3e3f3ff1171bbcbfec0e4e1ca1f2357fa694fff97770bc72893cf375cf9c564e1bc"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/255d9cd2-6371-4fae-9088-0e806faf145f/084be8348ba60f7cab06fc9e6e1a548f/dotnet-runtime-5.0.0-preview.6.20305.6-linux-x64.tar.gz",
+            "hash": "355a0a3e02970a5ecd2bfa06f4690ed8f7ee23bf5544470787c79c80ec5ff7d3a0296fed06d311d2b970fe00db0345856b5cea4e8e0cc3abfab8f2e89d0755e6"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8984e389-5e54-4315-8c1f-d642694a5a3a/fea8df55f4f3b81fbe6bfc57d547fc9d/dotnet-runtime-5.0.0-preview.6.20305.6-osx-x64.pkg",
+            "hash": "00f3beb35aab5b81bf9b72d0a96e15f8dc40afa1c34fd49fb8ab288d888799f818f332352eede62585122d3386b71d548456b1c6aad13d6217f8f57414cb9fe7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9bcd6a75-2d60-4fdb-ba52-bf8aac3cc8ea/30f94206874e28a08cd1af9b60f76833/dotnet-runtime-5.0.0-preview.6.20305.6-osx-x64.tar.gz",
+            "hash": "1c2b545904528872ee0b8012903b7a42e8980de4296a72f102a2cf696ca6c79acd5710f81d919c81c7fa9dbb5e3f23b2989c4c7799414be39a3a09a5e9fe5534"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d92cf82f-3605-4e5a-bd45-8b7582a8baa2/d746e5423390263a5fe5b5573ab1da2e/dotnet-runtime-5.0.0-preview.6.20305.6-win-arm64.zip",
+            "hash": "136a875a809d6d7bb54ae6b215ca96b6059504e9bd0cba0f29f8e1b660b52624d6c8ac77cf483131070039d6239b41614bdbd43aa591cd7e62ef209a63d5a76a"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9d9ad166-4ec8-44ce-a3b6-2c9157db98f3/5055fa1ac4cffdfdcfd6c7fc6a1a143f/dotnet-runtime-5.0.0-preview.6.20305.6-win-x64.exe",
+            "hash": "6821be7a59b0d21521a33ca3841a4132ee1f471c779ed353ef766c340818140156befd636a4a15fc76ac5aa0436697c251cf2a97db3dab07172947784d53a683"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7a9b311c-96ff-4275-a4ad-372e10730072/74369b63884ad2950c3304d86d124310/dotnet-runtime-5.0.0-preview.6.20305.6-win-x64.zip",
+            "hash": "eb7b8db4de0149ef14e367e7c8fc92f160be5aabf5380280b6b663afeec993595b674ccd4ece5032dd0187587cb97a1a39cc0d0b1284e913c537ad23aebe1ac7"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/63f91a7f-ba90-4593-915b-083f0ddcb076/b5da51ed6897d98f2f5c8c3f8054e745/dotnet-runtime-5.0.0-preview.6.20305.6-win-x86.exe",
+            "hash": "6053d306567d3c5098194375628d2613e304a0cb09e50d20d19345a05106cd98f20353717ec0f68d44034df8abee8ebdc0c1bc15d6feb3a47184352d206c52da"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0bc6ed8b-b2b1-407a-a68d-08262f1fb752/390fbdc3d59edb2ff9c771d76bb114c8/dotnet-runtime-5.0.0-preview.6.20305.6-win-x86.zip",
+            "hash": "ae3bff284b855735a7589402d6c3931bc9a2d236a3fdcd717a0406b3d8e3a8dd5601983c205b99fc72e496def942f26ae89cb8bab57cf5ddc6cce699c2b71f3a"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.6.20318.15",
+        "version-display": "5.0.100-preview.6",
+        "runtime-version": "5.0.0-preview.6.20305.6",
+        "vs-support": "Visual Studio 2019 (v16.6)",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fc54f62e-c7bd-43a3-a27b-4afb08bc4d6f/b01ccacf3d94efc0bbe26f64f7fde9b7/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm.tar.gz",
+            "hash": "1dd5c4f90d43983f1b6ccfa7631fd70afe99b26c1111d191dccb860bcfa232052c3589147f730b583b3f498bcd1116a131fae462267b68a00c10d7e7d832e65f"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/164ecfcc-df44-476f-a161-340201aa6fa8/7200eb764dc9ff546d384e3188f98a53/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm64.tar.gz",
+            "hash": "2a1039c4a94abd33949176407edee84dbd54053b56c7e2d8b69e7cf28e16f89013036cf662403ea8f2ea593b9b1b702e464762d9670da12507d1c1e06a58c04f"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6cfc5668-5c55-4ab4-9266-0d3dd00e6417/c03eb0deb48f9d2cf8d2bde4bf4d9113/dotnet-sdk-5.0.100-preview.6.20318.15-linux-musl-x64.tar.gz",
+            "hash": "e0c5283cd1758f921e25f4653c8c8a3076dd83602c8f036b347450695717ad3c071222b2467df27b8854c55e555f4ed095f9dc072d595caf6fe7b4abde6332d5"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ec4bba83-4586-4705-a6ae-c648861ca284/d9470c2f68161e3c2b8a0785fe7b3329/dotnet-sdk-5.0.100-preview.6.20318.15-linux-x64.tar.gz",
+            "hash": "ae68221770e8f199880f00a29d72c624aaedc0c3ca61a7b543a6555acf27eca4c0c24fbd4eddc1322d7dcb4f342325b1d1521c590556bd95c3c2ec653b914dbb"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f912c99a-c128-4436-8aa5-433cf502d0ab/4ebe252735cb7ae6cc828b2e0bbe107b/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.pkg",
+            "hash": "7c3f50b2b7fac2c41fe5074d706d67ee6e8edaa3eb464425ea884add51d92ae82f1a2571ff41ce3114abcdb91ebaa3df893bbf4f9ce2d666bb8a9577551004f5"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ae0be7cb-6553-43e4-ab1c-6355a0ac0b9f/e18a0be6d89ac4cde08e39ce232953b4/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.tar.gz",
+            "hash": "03bf06a62c040840825455abe6a94ee6833bc19fe8fb7a38012638a6d7e12dd2b0f0a5efb761c84152cbb09dd659821d2897153918a2dd3ed9d1b07de437e719"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/641b012b-5952-453d-a2b8-46aaab4b5ae4/c0e5b3a90d8027787b358658909695b5/dotnet-sdk-5.0.100-preview.6.20318.15-win-arm64.zip",
+            "hash": "8c0ec61a02daf5ad04b8286b50e90280b45179115400d2375b909d9241d857bcb73aeb929a5a9f42f6981de40252608a980e5118bdd7627686026653f891efea"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fd9433cb-270c-428d-b0b5-a29a0775248e/111429e1df10716fe6d85ab4e658b333/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.exe",
+            "hash": "cc112b2d93337f70e490861c9f0325d55fea51867b1b53d0157778ec61e776e7dad99a929724aec2d35d809b2c4f80c47e4783150fd6f522dedebddbea71a9db"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/95161504-111d-44b6-a769-72c07d7179a7/47fc56c03ee30f612e1e34e1b7430897/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.zip",
+            "hash": "46ecc1e10aa9c9296675af55fe93bf003d3984b761e1c1d2af823a24b355ca99e0bce9ceb8856ec29ee1c3dd430c01c0b55901a853a1ef763397eadf9045e01e"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b0062077-f955-4b97-94cd-454f740ff142/ccb371f6fd4b2ca1f54ac0e182778b5f/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.exe",
+            "hash": "ab14ae0af4103083a4794ca514ba6c5e9ef69d110b099b0ef60df9ffec8a8f1bd5aad280138da9cdec36664f03b83804e1c90bc0c4a647731e190cb8847cad4d"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7f2c7990-e7dc-4937-881c-b58e43f24ed0/78c3c9fd17f4f89c7de4a45d9f17dc00/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.zip",
+            "hash": "231a0fb7b959b8ea90e16fe03806920d6f60dc54eb537698c0acbbd68a30d92bfa1aa31b1c00798d08d2b0b28554907a0f467cda06fa78d398144f2468a596e6"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.6.20318.15",
+          "version-display": "5.0.100-preview.6",
+          "runtime-version": "5.0.0-preview.6.20305.6",
+          "vs-support": "Visual Studio 2019 (v16.6)",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/fc54f62e-c7bd-43a3-a27b-4afb08bc4d6f/b01ccacf3d94efc0bbe26f64f7fde9b7/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm.tar.gz",
+              "hash": "1dd5c4f90d43983f1b6ccfa7631fd70afe99b26c1111d191dccb860bcfa232052c3589147f730b583b3f498bcd1116a131fae462267b68a00c10d7e7d832e65f"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/164ecfcc-df44-476f-a161-340201aa6fa8/7200eb764dc9ff546d384e3188f98a53/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm64.tar.gz",
+              "hash": "2a1039c4a94abd33949176407edee84dbd54053b56c7e2d8b69e7cf28e16f89013036cf662403ea8f2ea593b9b1b702e464762d9670da12507d1c1e06a58c04f"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6cfc5668-5c55-4ab4-9266-0d3dd00e6417/c03eb0deb48f9d2cf8d2bde4bf4d9113/dotnet-sdk-5.0.100-preview.6.20318.15-linux-musl-x64.tar.gz",
+              "hash": "e0c5283cd1758f921e25f4653c8c8a3076dd83602c8f036b347450695717ad3c071222b2467df27b8854c55e555f4ed095f9dc072d595caf6fe7b4abde6332d5"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ec4bba83-4586-4705-a6ae-c648861ca284/d9470c2f68161e3c2b8a0785fe7b3329/dotnet-sdk-5.0.100-preview.6.20318.15-linux-x64.tar.gz",
+              "hash": "ae68221770e8f199880f00a29d72c624aaedc0c3ca61a7b543a6555acf27eca4c0c24fbd4eddc1322d7dcb4f342325b1d1521c590556bd95c3c2ec653b914dbb"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f912c99a-c128-4436-8aa5-433cf502d0ab/4ebe252735cb7ae6cc828b2e0bbe107b/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.pkg",
+              "hash": "7c3f50b2b7fac2c41fe5074d706d67ee6e8edaa3eb464425ea884add51d92ae82f1a2571ff41ce3114abcdb91ebaa3df893bbf4f9ce2d666bb8a9577551004f5"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ae0be7cb-6553-43e4-ab1c-6355a0ac0b9f/e18a0be6d89ac4cde08e39ce232953b4/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.tar.gz",
+              "hash": "03bf06a62c040840825455abe6a94ee6833bc19fe8fb7a38012638a6d7e12dd2b0f0a5efb761c84152cbb09dd659821d2897153918a2dd3ed9d1b07de437e719"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/641b012b-5952-453d-a2b8-46aaab4b5ae4/c0e5b3a90d8027787b358658909695b5/dotnet-sdk-5.0.100-preview.6.20318.15-win-arm64.zip",
+              "hash": "8c0ec61a02daf5ad04b8286b50e90280b45179115400d2375b909d9241d857bcb73aeb929a5a9f42f6981de40252608a980e5118bdd7627686026653f891efea"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/fd9433cb-270c-428d-b0b5-a29a0775248e/111429e1df10716fe6d85ab4e658b333/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.exe",
+              "hash": "cc112b2d93337f70e490861c9f0325d55fea51867b1b53d0157778ec61e776e7dad99a929724aec2d35d809b2c4f80c47e4783150fd6f522dedebddbea71a9db"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/95161504-111d-44b6-a769-72c07d7179a7/47fc56c03ee30f612e1e34e1b7430897/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.zip",
+              "hash": "46ecc1e10aa9c9296675af55fe93bf003d3984b761e1c1d2af823a24b355ca99e0bce9ceb8856ec29ee1c3dd430c01c0b55901a853a1ef763397eadf9045e01e"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/b0062077-f955-4b97-94cd-454f740ff142/ccb371f6fd4b2ca1f54ac0e182778b5f/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.exe",
+              "hash": "ab14ae0af4103083a4794ca514ba6c5e9ef69d110b099b0ef60df9ffec8a8f1bd5aad280138da9cdec36664f03b83804e1c90bc0c4a647731e190cb8847cad4d"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7f2c7990-e7dc-4937-881c-b58e43f24ed0/78c3c9fd17f4f89c7de4a45d9f17dc00/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.zip",
+              "hash": "231a0fb7b959b8ea90e16fe03806920d6f60dc54eb537698c0acbbd68a30d92bfa1aa31b1c00798d08d2b0b28554907a0f467cda06fa78d398144f2468a596e6"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.6.20312.15",
+        "version-display": "5.0.0-preview.6",
+        "version-aspnetcoremodule": [
+          "15.0.20164.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/73088968-f3eb-46c5-b762-93118fdc43d3/bb4f75b42f0c4ef4fb4d0fba67a88743/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-arm.tar.gz",
+            "hash": "5243d7e3e68f5d0e4ac334d00405b3a4a81b6700f5897e3a68cc388c42f70ffbfe2bb41c39466c76ad98996591e88190c079c03dbf23704be6144d763020985a"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/35bc810e-7447-4989-8690-a26bea89978f/8b2b16cdcf73aeb3987a08a4d968fdb6/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-arm64.tar.gz",
+            "hash": "8bcee151e9a0d41654fe641e9c949ba053394b345ff8250d591929ffb44e9163e800093d1eadfe810f608f87217e27051ddfb284969db71bb386db9ff8b2389d"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ef32de56-e8a7-448f-bed1-f1e8d1b52d61/a83be851e55a895c57001c69e3c40048/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-musl-arm64.tar.gz",
+            "hash": "2fc1bafb3963ee7f0a250f980434d47b81ce7bad41311eda1391c1d72591bb18b3e49f8aca1331fc4ae2a928d840c4b56809579bf835a427ac4a4208e3ce6136"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/81466dce-451a-480d-b6b1-6dd26841c057/ca724a89b6af524b13a3d8065fdb51d3/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-musl-x64.tar.gz",
+            "hash": "157b73945e553947147622382fdacbc0649523c383a3bd5a1c65bfbb026e6fead39ee1260af41f1a8c574be0f87d462f18bca540c594422c1f8b4f09e52b2c93"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/72d81bfb-18f8-4f32-bcf2-b96bae1f648b/bcb3c3f6092b646aff08775e48ee1738/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-x64.tar.gz",
+            "hash": "237019e067d89f0b62d68793f17607fd484a2a9e06ab2423bd31d17fc42933f0d3e1112399309c93da243b0943bcd7317b389efcf83e6cda544dab1a82101bbc"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fb1b59dc-ad8c-4c34-95a0-5eb202916943/9bcbf60f802cf4c9ae67914a57141072/aspnetcore-runtime-5.0.0-preview.6.20312.15-osx-x64.tar.gz",
+            "hash": "330e12e8c52bd4fe07756a6bc3871a5e8838be736f97a238e26d5d53a74d53069a6c330e475bcc38fa68b44cdd6be585d382d20a817a8823783db4428ee352d2"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ba06eeb6-f5a7-484c-948e-fdcf22ad6198/394e1ea9b4886df2a365085a9ac8cd2e/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-arm64.zip",
+            "hash": "b576a35e31503b1b5d1c2e8b01f64bd4047b4ec76cd528ea6b0552be44318c50a4db276767c0e3852e162b6a286222302440cad57ed1599f83ce10181e023222"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9214582e-ff80-4f31-8b88-5fa9d4b776e5/606ea8c457382a4636283045ac50db6a/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x64.exe",
+            "hash": "41380dcb37876ad7ad4111c872887e67343ad2087072ba634bec4e0544c68c8dd99a2f252530a711fa23cdac00a03528533ad5e305632fe8398df0e518b5a0fd"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5f067ed8-d2e0-4272-a118-8007892b3fa2/3fecfd00d6263446e1d1ea60059c8acf/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x64.zip",
+            "hash": "d46f3b92142ed50ba9352bf36c100657028c67700f56617f3df5a050ce2015e8156b1739ec67e49c2d4fb425be2e08c7083513a2a950698027af6bd486e181c6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9689303a-21cd-43fd-9d4f-a68ee39e190e/542ff84d8e9df559e847bd2bc7200a21/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x86.exe",
+            "hash": "2a75a810a696020a8fc8fd1d8a9d27b53cc3bcfd55fd318925169de8a7db0776032f81d074288d766072beab924108c7f70abec60a054d7bcd77d28591025539"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4a0ac3d1-1444-4996-9c2b-098890f4a9d1/4e8d5ec188c9e03d4bc74e689823be83/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x86.zip",
+            "hash": "81b5f72b496b917d1b8977a9cdbf30bb305bd3d6f812e8180a80c20ca66ebbb12251ae549429a76c2a551b65f98b4e88766876ef70e81abc5da1e9113cf36a6c"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2563f05b-8dd1-4d66-92e0-2766ac653df9/cd36906fb799128ee9107e55194cf505/dotnet-hosting-5.0.0-preview.6.20312.15-win.exe",
+            "hash": "8ca3235e36655127a0193d6c88a8a812c1795c1e254f0b41223759239843b5cd6275d026fc30ed7678bbe50fa4c90d2318e974a57f9e6394861f39d9879e8a09"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.6.20308.1",
+        "version-display": "5.0.0-preview.6",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/829c5f36-4be5-4bf0-bf2a-a951ac1a53a9/dcef53f6325d9f055f704e0ebcce4fca/windowsdesktop-runtime-5.0.0-preview.6.20308.1-win-x64.exe",
+            "hash": "4328aad877464821319960ad5ec4795ce8c4f8a99be755c0757326a56e25b800fcaadbb255ed5e91cff018f25b89823bd4b424c0112535263dfc5492c95b47ec"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/877d2802-6181-42de-9ec7-3aa99941c75e/93766366e5475a969ebf514c8bd3f93f/windowsdesktop-runtime-5.0.0-preview.6.20308.1-win-x86.exe",
+            "hash": "a14182c51ea60db77c0428a8b4fa2c8f4c18c48f3d282a67815b3e1929dfd1f5fc9fbf5d191033192a131688fb43988a7d0440fc27518bc1b1f4ad3d2054c7bf"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.6.20305.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-06-10",
+      "release-version": "5.0.0-preview.5",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.5.md",
+      "runtime": {
+        "version": "5.0.0-preview.5.20278.1",
+        "version-display": "5.0.0-preview.5",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/51a30257-7167-452f-bb48-8bf52874a312/3442cb330320a26a2b6a060202f4ee7a/dotnet-runtime-5.0.0-preview.5.20278.1-linux-arm.tar.gz",
+            "hash": "fbe871f82c7c61195fae789af415c2efd03dae982e131c10cacd95b744b0f498774b014bcb3523cf52153104fdad81759f84e2e72bcda7eec48e3530ffb03e60"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/875a8949-420f-4fdc-858a-30f293a4cc9b/5b44049862dc82764c6e03120d52a9b6/dotnet-runtime-5.0.0-preview.5.20278.1-linux-arm64.tar.gz",
+            "hash": "d081750334a49e9ed6b75468d937e02ce247d8a8f0c66505d048174591a35fd433fc0febb0b551dcaf8a823190cd92fb6578c140f0fa4af859c911f622963724"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b1e4ff98-4e4b-4cd6-981e-33acfc20bc7a/840d6032bc7e4dc55c4d03a6ab44ab98/dotnet-runtime-5.0.0-preview.5.20278.1-linux-musl-arm64.tar.gz",
+            "hash": "249ea41018c76972c2f3e54dbb515b75721a603435cfa9d1100e32a05c3c832674d110729f63d9cbb44768d8444e4799df1bab407f836eb10cd1b3c554259b9e"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f23ebe0b-74be-4fd3-841b-123b32dbcffb/3c33ceb3af2f23632689e670fc9fc397/dotnet-runtime-5.0.0-preview.5.20278.1-linux-musl-x64.tar.gz",
+            "hash": "4e1b8147d82045fb58812a90ae9e70810646dde335844be390ac6adb839f1219fd19811d63e345881532a0d27af91e633cc462218ca7a34d429a3731f7b5a686"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/95306227-0c75-4645-87ef-3d5b46af79a4/bb4aeba4db192c2a62fac09cb797ba08/dotnet-runtime-5.0.0-preview.5.20278.1-linux-x64.tar.gz",
+            "hash": "1bed1c8ee4185c0ced69e415dc25a5040eed68d0d6a7c35c6a83fbe1eb3f71e99e8c9b631a34825141163b9fe105b281f6c7d5d39bbcf40f20b9d81fdb7384d5"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ed4dddfa-d703-451e-bd2f-8dfbe81a735e/9b15085e7d4be3d3c881abc24db523b8/dotnet-runtime-5.0.0-preview.5.20278.1-osx-x64.pkg",
+            "hash": "c4d17cce8804fce39e731bc6a95bbb08bb8a175b6c43bcc2e1bf73c8236b11cfd32cc8ac953a1c15c5f7e15da9013dcd3f25a0996697706316b4ae185ab0a11b"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/896a86ec-29db-4915-b2c6-f2f7b4e672fb/27fe60394d6a00ee18c37038b9e3280e/dotnet-runtime-5.0.0-preview.5.20278.1-osx-x64.tar.gz",
+            "hash": "d672ee9f489a10b33b26626b5959d9dcee8f54079004991615367492eb2c2232299bc3655b1a4f9270b717feffac54466d74a1a8d6e192a367b1e5cfe3a78d1a"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7e01b3e5-e9ce-4e9c-baa1-ba71a6c7b415/dee7f90305b7bbf9a95d5529cf125eee/dotnet-runtime-5.0.0-preview.5.20278.1-win-arm64.zip",
+            "hash": "0d8e5f049b5022d3ece6e2d8c244f819ade33bcbd4d251cdbfd97811fd2da271eca32cadea65f3d1ac99ec4b642ce16dae8b089b3869f5cc2e8db958490a43b4"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/add3d66a-0362-4963-9cb6-995a35bbc462/8641decedefe5f3026ea00cfb669667b/dotnet-runtime-5.0.0-preview.5.20278.1-win-x64.exe",
+            "hash": "908cb1b453e4bf7f4f03e088f84ecae0ce20e4903527584a246fea75278b9eba48716bec35beef011718efb8518df1067c6937ac20606e41f206dd914b69610c"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/77eae450-bf51-46dd-a464-c705efe62f7f/89c0c2c7a7eed4f492a8cc2ed4342f00/dotnet-runtime-5.0.0-preview.5.20278.1-win-x64.zip",
+            "hash": "6178f4ba6a4bd578eb0a3338621cb26bfb0d92936b1b9af2dbc66d9dd028d1f4e20e58f191eef5e52293b46e3e84a3332a123494bc572822ac68ec05345e8204"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5a1a5d33-3e09-46ee-941c-73ed1f4e5092/dacf37c9b40b973f78a11c95e9550d51/dotnet-runtime-5.0.0-preview.5.20278.1-win-x86.exe",
+            "hash": "ecf24922e05b7e155356171b7e85393284a840d313e83ec9db52a804555d381afaf97759a9d6a59e2459ff20ef9071dcbfaef483485ba22f6895c53fb11cccbd"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2ea3be64-1cec-4ded-a992-703de2aa40c5/1eea262da0c415e926a6b411c2def271/dotnet-runtime-5.0.0-preview.5.20278.1-win-x86.zip",
+            "hash": "3da31d2e6e923b4d56b2920d68a8bb1463e0c733f0309835b6a54c15506be21aff64ecd35e762f9208eb2e001b512e3e32562f6a0dbbecd17a9d82547bc52b50"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.5.20279.10",
+        "version-display": "5.0.100-preview.5",
+        "runtime-version": "5.0.0-preview.5.20278.1",
+        "vs-support": "Visual Studio 2019 (v16.6)",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6fb3f700-22ed-43d8-8f54-8152f359054b/050d3254d477aeb124a45d0cb13f864d/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm.tar.gz",
+            "hash": "6256e013e0e1a153671b9ac3afb49db2646d5e9710112626f52f91070e9832fd17c475414387c6d544dadf2b62df342400d7c34ac01e7a1807d53587ac2d0bc8"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a529731c-7c51-42f4-9386-46c6466019dc/e408a0275c2333ae29a6e31c00c1ae64/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm64.tar.gz",
+            "hash": "426caa42f586f5213169828c8ee049f10bb8ee0aa1c8961d006396e74c995f0cadc88c9dffeb13f573f3b21bdd9a11279adb0f00bccd20f38da66153b8be43d0"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/190ba32d-e1d5-442e-ac07-09b002e5750c/da229668b853a5912bdf1b224dbd371c/dotnet-sdk-5.0.100-preview.5.20279.10-linux-musl-x64.tar.gz",
+            "hash": "441ccd3e724599d187363fcc3217e5077efa68218a86b2c7dc24ea776de6618ba9beef3ee2c856e4bffd39aeb4d7257c619af8f8db4ec94cacb2aab35f920b50"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7cf9fa3e-af03-4181-baab-e04ed4b05268/fd44776a5169d6b126ee11d6140691be/dotnet-sdk-5.0.100-preview.5.20279.10-linux-x64.tar.gz",
+            "hash": "0ee982dd7b6015d05c04a33ffba77fa9f61863578c5fd7c4b3847043da2fd17c36b2f8535af53f46dee66e9e59a52f5e7c995af7f9a69fbd3abbc524aca5931b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f63b5b1e-25f9-4213-a147-ca8a252b8e27/094a39437dfc8f03eda852b36b499115/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.pkg",
+            "hash": "cf9f15e8a10fa44988efee31d6a5d610e088555c6116736528682ccbe4ace6791f68751efbfded7c55e1d8202abc77dc1c9a1656a5783b13db9acc95894a615e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/34e0dc05-8cf3-4deb-a9d2-14a697684cf3/5b37bee096f464f04393ac35cea8439a/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.tar.gz",
+            "hash": "91b693142b8e7551cdb9cfd304cf62ec01dfc6d429fca9635976355528319199c5e072d8b62b2e7341ef449429fbe12ca992b9802725d4ebc7a8139b99203775"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ecd42d26-c097-4755-a5cf-1e1cb0365d62/e71a36687a026248792177e2b42d0602/dotnet-sdk-5.0.100-preview.5.20279.10-win-arm64.zip",
+            "hash": "007032f39d8e52b1e77a2e0f1a1829d51631ca6b6f1dd25b522dcba8abcc474f87e80d3eb4aa00ef3ae19caa8f13f2cdeac3b2fda2369477ef5efb2a188bedde"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/38c82743-6223-4a51-a424-ac79a4db189b/5c88aa3116df3b81564077fe49a83c7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.exe",
+            "hash": "82fdb454f78f659dc43f94cbab034396e10bb1a16ac0101bf9bf473a5e88b3ce441f496a91a89e102deb3b356bd6717128c5a8fb7266896a823f22f95df65083"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d4c38dd9-6cfe-4e0b-91d3-511ede217bcc/6e6a85d8a85194a416503d1a103e95e0/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.zip",
+            "hash": "086927a537acd60cfe71cfb760d01659c77a7f918f1848b9b5776759043e45d3ead0f394aff6b45cc01f8c0f5f0fc22d0fca5a8ba478b9d514d56547492789be"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6163690f-c627-4063-9229-fed74d955402/e33f89f431867b98e1a74297fe73cc7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.exe",
+            "hash": "87027008020a566c53621c6bc7b67a7ddc6bf621c11b5cbad01c38c4a74958ef904161e35d48b985ab0d5bebdbc792029ef8f62eb8a10b3680ba20c91ca97461"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/63061248-531e-488d-a9c8-794a33a06ab7/910cf966d38c953d94d3140487786bb7/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.zip",
+            "hash": "2a906c071d3c32f9f2be846675dc3a487ea6e9127ca5dc9cbcf35d3f57cfd4817df1b006360c0455bbb6cd2e711296ccf4250733013b0740ca04509186c8e549"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.5.20279.10",
+          "version-display": "5.0.100-preview.5",
+          "runtime-version": "5.0.0-preview.5.20278.1",
+          "vs-support": "Visual Studio 2019 (v16.6)",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6fb3f700-22ed-43d8-8f54-8152f359054b/050d3254d477aeb124a45d0cb13f864d/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm.tar.gz",
+              "hash": "6256e013e0e1a153671b9ac3afb49db2646d5e9710112626f52f91070e9832fd17c475414387c6d544dadf2b62df342400d7c34ac01e7a1807d53587ac2d0bc8"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a529731c-7c51-42f4-9386-46c6466019dc/e408a0275c2333ae29a6e31c00c1ae64/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm64.tar.gz",
+              "hash": "426caa42f586f5213169828c8ee049f10bb8ee0aa1c8961d006396e74c995f0cadc88c9dffeb13f573f3b21bdd9a11279adb0f00bccd20f38da66153b8be43d0"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/190ba32d-e1d5-442e-ac07-09b002e5750c/da229668b853a5912bdf1b224dbd371c/dotnet-sdk-5.0.100-preview.5.20279.10-linux-musl-x64.tar.gz",
+              "hash": "441ccd3e724599d187363fcc3217e5077efa68218a86b2c7dc24ea776de6618ba9beef3ee2c856e4bffd39aeb4d7257c619af8f8db4ec94cacb2aab35f920b50"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7cf9fa3e-af03-4181-baab-e04ed4b05268/fd44776a5169d6b126ee11d6140691be/dotnet-sdk-5.0.100-preview.5.20279.10-linux-x64.tar.gz",
+              "hash": "0ee982dd7b6015d05c04a33ffba77fa9f61863578c5fd7c4b3847043da2fd17c36b2f8535af53f46dee66e9e59a52f5e7c995af7f9a69fbd3abbc524aca5931b"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f63b5b1e-25f9-4213-a147-ca8a252b8e27/094a39437dfc8f03eda852b36b499115/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.pkg",
+              "hash": "cf9f15e8a10fa44988efee31d6a5d610e088555c6116736528682ccbe4ace6791f68751efbfded7c55e1d8202abc77dc1c9a1656a5783b13db9acc95894a615e"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/34e0dc05-8cf3-4deb-a9d2-14a697684cf3/5b37bee096f464f04393ac35cea8439a/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.tar.gz",
+              "hash": "91b693142b8e7551cdb9cfd304cf62ec01dfc6d429fca9635976355528319199c5e072d8b62b2e7341ef449429fbe12ca992b9802725d4ebc7a8139b99203775"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ecd42d26-c097-4755-a5cf-1e1cb0365d62/e71a36687a026248792177e2b42d0602/dotnet-sdk-5.0.100-preview.5.20279.10-win-arm64.zip",
+              "hash": "007032f39d8e52b1e77a2e0f1a1829d51631ca6b6f1dd25b522dcba8abcc474f87e80d3eb4aa00ef3ae19caa8f13f2cdeac3b2fda2369477ef5efb2a188bedde"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/38c82743-6223-4a51-a424-ac79a4db189b/5c88aa3116df3b81564077fe49a83c7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.exe",
+              "hash": "82fdb454f78f659dc43f94cbab034396e10bb1a16ac0101bf9bf473a5e88b3ce441f496a91a89e102deb3b356bd6717128c5a8fb7266896a823f22f95df65083"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d4c38dd9-6cfe-4e0b-91d3-511ede217bcc/6e6a85d8a85194a416503d1a103e95e0/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.zip",
+              "hash": "086927a537acd60cfe71cfb760d01659c77a7f918f1848b9b5776759043e45d3ead0f394aff6b45cc01f8c0f5f0fc22d0fca5a8ba478b9d514d56547492789be"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6163690f-c627-4063-9229-fed74d955402/e33f89f431867b98e1a74297fe73cc7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.exe",
+              "hash": "87027008020a566c53621c6bc7b67a7ddc6bf621c11b5cbad01c38c4a74958ef904161e35d48b985ab0d5bebdbc792029ef8f62eb8a10b3680ba20c91ca97461"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/63061248-531e-488d-a9c8-794a33a06ab7/910cf966d38c953d94d3140487786bb7/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.zip",
+              "hash": "2a906c071d3c32f9f2be846675dc3a487ea6e9127ca5dc9cbcf35d3f57cfd4817df1b006360c0455bbb6cd2e711296ccf4250733013b0740ca04509186c8e549"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.5.20279.2",
+        "version-display": "5.0.0-preview.5",
+        "version-aspnetcoremodule": [
+          "15.0.20150.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1c2aaaf5-a2e4-479e-8e66-c75415ea167d/b4b71f1a89af057334187b0c36d5b6dd/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-arm.tar.gz",
+            "hash": "bb021d67206f48bfb21151181bed0f1b5455a2216c9e9852b0872f8e13d316bb389aeb3cdbe96023f0623d841f7eec0c12624af6749b431175034a883bfe30b4"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/adc871bb-2eb6-4083-8665-a005367fff17/a76aee5f824dc9876a6d27adf9be28a6/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-arm64.tar.gz",
+            "hash": "68491c16bed5f7fdebc5c806daae3857462b6589cfd2dab0d84f753eefa735a705f72beb1914fe189b40ff274bd658b7c3fefc6ff7c0f9178bdd46e88584c7a6"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eae4efcc-9105-45ba-a1ee-3a79f9ed51af/f879cce5713bb029254eba12b4aecb0b/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-musl-arm64.tar.gz",
+            "hash": "0a25aabc07122423ad034809b2806b9322c4e32f965704cc34e828830ee1e6466d117617c37f9cb350d6fe4b7d6165d6eb2c974161949870274f4246800d9121"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5bf853cd-5736-4411-b853-0f6e24430d76/de830144eebdb7f681c1bdefd403c9a3/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-musl-x64.tar.gz",
+            "hash": "6377ac079540d502902b4ff621638400411f3411839cf711ac49c0f9be63c9eb408febea6e01ef9a81d2c4700263e5d5e57752226f3be0e7980894e9211e2ec3"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c4697b7a-c408-48e9-8d80-4ead593ee22b/8d03d322a7ca93efa1e8dbe66cf7a781/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-x64.tar.gz",
+            "hash": "5f1b1475f27a07b4d1af2c4bb293f53dc517ed33208669f74f468cbb42773cb4cf01649a13bcefa7070532f5881fe2a61709d029c6f00233790a5205a355e9db"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6aac3844-086d-48d5-9ed3-35ba1df3ba5a/587b8b0af9dda657c2331a3a205d2bf4/aspnetcore-runtime-5.0.0-preview.5.20279.2-osx-x64.tar.gz",
+            "hash": "4e9a7ef33a18ba242c751a289ff67446ec7295bdf32df9670ffd4e4fb7fcdf4fb09318e8ebb0f3afe0743303f240ffddcf979f0f860054b6c7d08626dda37bbf"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/42156656-028a-4974-8a9a-cd368740e8fd/c16e719c0636401dd3e7442c436e2b15/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-arm64.zip",
+            "hash": "5783850847619a6cbb3a50acf9b2b6df0d9031b6c1a18769ffee44c320953f88e56e78ff5537a37f58ad0108009dff90a79702a463f90e6f2adc304b32e8897f"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9159b7cf-5285-48dc-b391-14cab2fd15c0/c3ce1d1d230bb2afc924c18b652f68f9/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x64.exe",
+            "hash": "fd5e74efd0c8ccddce9777f0425656b90b402d6fcf249afe4a0aa22492182819e34583b89d2725bcc682a919efd66b0d32c510a1e20891557dcbbf1f95198aff"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/36105bcc-125d-4269-8504-2c5fe5401fdd/11b4934407d307ab9f3951b6bb1a791a/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x64.zip",
+            "hash": "09646e89c04993ee42a5d072e5409fe6f389df41f20df30f6c3074d066725606b3958cc9ce07aaa444d4e3b5880800b69dcbeea2a9112059a8ab0b02b5cdbcd1"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30e238e3-b342-4c67-a71d-e4220625f52d/e11097c56bd2707b1207de183ef3fcdb/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x86.exe",
+            "hash": "c1afc15206ba8d3db205b8e8f79be31be720424377b4ea223b187f2b813310032906328248479e71d4f7826d9852985e876161d61ff1cc02fb889911674d7a95"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/16474f86-f8d4-456e-85b4-7cd5e2dfe5f4/8935d76519cfa109128ecc66648a8732/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x86.zip",
+            "hash": "3aa29bc08ab2845e74d56957df90c8daf977a26bd394b75c274e465c4c3a9d678e950e98e444239e85cdeff6aa116242704ea9d45133955d8b53617e9ffe7440"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b1aaa280-c8d3-45cf-990e-cd1c736bb474/0c964ee4264bb54a5893d434942b7c73/dotnet-hosting-5.0.0-preview.5.20279.2-win.exe",
+            "hash": "9b8074c8ae9d4ac511d765effddfc61f7f023fe1cad8158ee707c1b3db4e496de329449b95c1d32204986efe19e2d06626907b6848335bd8e9cd21bfa2f3b39c"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.5.20278.3",
+        "version-display": "5.0.0-preview.5",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6cc1a99f-4e83-408f-95aa-b44dfdc9bc56/88d52d94d7f4f96c1313cb95d72c8515/windowsdesktop-runtime-5.0.0-preview.5.20278.3-win-x64.exe",
+            "hash": "196cf646072177d62b964bb71c480eef7c25e91658e9a2ac4de885f058ea9068b6d05bcac0383a9f03c7c559838458ef01c3d1ed7309bc0e25127a124f9e8004"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94c3c646-f95d-41d3-a534-6617b3edfe87/4e36ed04c3ea19e82a42104982d1fd3d/windowsdesktop-runtime-5.0.0-preview.5.20278.3-win-x86.exe",
+            "hash": "83a54b3a503b2d27972fe96d9a4f7185e8857561f65c3b9d1733d015a66cf1651cdf5973d53537ba85b0cf75204e27038159431c94532f9c4db3a4872c05a63e"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.5.20278.1",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-05-19",
+      "release-version": "5.0.0-preview.4",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.4.md",
+      "runtime": {
+        "version": "5.0.0-preview.4.20251.6",
+        "version-display": "5.0.0-preview.4",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fecfc81f-44c7-41f0-a158-894ca434876c/28cba3884db133373305a03a48f01eeb/dotnet-runtime-5.0.0-preview.4.20251.6-linux-arm.tar.gz",
+            "hash": "1648b613453cfafb755cfb43bbfe81ad7102f181b3a96e2b4ee3b71065b59271f2a1461a90961d416efa098bae223fde0b56e06d3b44ff60b36c0ea3394080fd"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d122c932-67f1-4358-9bdb-64cce009ee27/0a46b82fcb16e952491385149896ccda/dotnet-runtime-5.0.0-preview.4.20251.6-linux-arm64.tar.gz",
+            "hash": "c691e817b72377027936311c7fc8a7a04867ad50fd5189e41caa9222178248d01ad69e8b0fe5e5400815d06c740d9f0ff207e46ad9655dcaa032ee2a2a0c0ec6"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/88c44f96-64fc-47d5-9ff4-58a9cb391887/0f9439c08d08d4e55dd8bb33d7a88c55/dotnet-runtime-5.0.0-preview.4.20251.6-linux-musl-arm64.tar.gz",
+            "hash": "9c3a7b23dd4a0967c66807c899e3ebdc703d863f970ad98cb1ff8950f46a20304db5ba05218bd0b965b28cce5b07b2e790c3a8b89b2c787fdf93713ed8949151"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5da9bee6-e4cc-40a9-9d00-b7b768912a6b/8ca8d545d1e702a984b1f92b44351f05/dotnet-runtime-5.0.0-preview.4.20251.6-linux-musl-x64.tar.gz",
+            "hash": "cdceee3294bbf995b0ff78d6a498be158bcf19d6fb8d8f68d5ec07288e12abad368047298b299e367aa88e00fca796aab70dd3d1ac5b0310f8d1b3ee2476660a"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8be8a5dc-f552-4a64-a55e-d112ab2b0083/7eb1023a4c6937968c5bbfbb05784bb5/dotnet-runtime-5.0.0-preview.4.20251.6-linux-x64.tar.gz",
+            "hash": "7b3e90ccab3abd95bc678551a1778abf8d672978c598974669ba84418adc37d5bf2393a8c194adece7e86998418713e18571953f8ff7bb5780026d8814d882cb"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/25a7898d-1bb3-4472-bae9-ed24c8b4124a/dedf9dbb6d310ac5a9616d7b67fc77d0/dotnet-runtime-5.0.0-preview.4.20251.6-osx-x64.pkg",
+            "hash": "47f022a71c21bd15c21eea4c0a47abb2ed92a117a9c89aa03cd2c7262aef2996102d228e8d0c8e5a7d93beb7cb9205cc8259056e2e402662f72ae2a2447dc0a4"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c522d0fd-ab05-4b4c-9c06-2974973a7796/f202496a9c3b2e160c4b46944f90fb39/dotnet-runtime-5.0.0-preview.4.20251.6-osx-x64.tar.gz",
+            "hash": "a7cff64708e6ac4432c485677650fb6e7805b24088aa448db9ebe0ff2b474e051cef87e6ef2e3ae8d45e84e3db98c082a90de677f9d95f809cc1f7c2b725576d"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5357cbc2-260c-486b-813b-08718fdcead4/cf3f79f8f5ac8b4b70d87b17e5917b62/dotnet-runtime-5.0.0-preview.4.20251.6-win-arm64.zip",
+            "hash": "e636004e3970e86478b2986252a50e34a2c32d92d4e5472b214fba4f81bafd929e37354f0e01212a6ba9ffacbf76d6f73429452c4e90f7ce525eb0b3dad2506e"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9a9e23ff-e724-4a85-be65-f3e99ebc6ead/24eb14ba173f807b12e3144dbb519931/dotnet-runtime-5.0.0-preview.4.20251.6-win-x64.exe",
+            "hash": "cbb041821cb1cb8512854f1361a5c662ab1c680ef308ec7d15df7acf15fb540c4c68ef60453bc869661194b618fd27d98c85e03afb981966e0aec299161a24b3"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/00e54b94-7eb4-44b6-84bf-405e8fc63fa2/4f0ee4bd09cad478c12e0ec418dc9f30/dotnet-runtime-5.0.0-preview.4.20251.6-win-x64.zip",
+            "hash": "c666a02299e2aa6f20dd5718c90cea1f496712cb93fc7cc300d2184cdd84509647c60daa48f4db4ef4d2e3ac2718c9c50b5d1d8fc139f89e74f1e87649c03c42"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/702a4f3d-3dd6-4a56-94e8-54559f981535/1b79a497066c5c539c5876dc48a280a4/dotnet-runtime-5.0.0-preview.4.20251.6-win-x86.exe",
+            "hash": "fc921133a0e8b1f7a24993701f969f32bf9450659cb5c4bbfd5ea828716425887023ed507d938aef52db60e3d8d79cdd85e950e907e5d47c90bfc806a019739e"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2a5e1f9-34c9-497a-8606-1bbf12d54ab3/5b520a8b1def8271a89d2215bf643692/dotnet-runtime-5.0.0-preview.4.20251.6-win-x86.zip",
+            "hash": "ae6edf9a4b9c3a0d25f1e4445fd5fb5efff5caec602c004392b2e399ded86b1ffa05152efb00d9128bf6b32ee9ec6050dd3f7f325824c48c1f367d758056eb8d"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.4.20258.7",
+        "version-display": "5.0.100-preview.4",
+        "runtime-version": "5.0.0-preview.4.20251.6",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76bea762-22d3-4ce8-a3cf-64276d4b9aca/74a7bed0b9e67a11cf025115c52506ca/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm.tar.gz",
+            "hash": "912f33feb15a00cc7d983e2ed7c42750de013f072e5c6f0162410cca5b2aaadb146bfd09f0f4cc7c90ccaacbc5a5301bc91cfbd964312d3e44d5ff6c944baf64"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/adb3ed49-26af-40a2-8df3-1460b178e55e/01187433dc24decf562d90d4bb2ce058/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm64.tar.gz",
+            "hash": "36e13d6cf4dce12d5f5aa6bf4fa903a2bbe1b816b896ced4ae388514a3ae7a40fdbd918893e7cacfb3f8c8e328995c5c0cce49973785e05568b00aaf6eafe9b6"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/02c5780b-df7c-4b37-a936-10d5d91259f1/7222fd36139fc536e795f7341fb0700b/dotnet-sdk-5.0.100-preview.4.20258.7-linux-musl-x64.tar.gz",
+            "hash": "2da9779628928b896a4285494349fa55efc987633d918d2c136017db6c4179f9ffbce871d1840bacc2c9e06dd54023bfcacd1cc51fbbeb2eaf1ff2cd175a91c6"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/473651e3-55d5-4e7c-b255-2cbe11358eea/6b6f33d86ee00720b36a7c34200f4d0c/dotnet-sdk-5.0.100-preview.4.20258.7-linux-x64.tar.gz",
+            "hash": "d84fc2795ae6128299d318485a5e9ed8717f38aff83cac57ed9baa95785c33db7153e1d44aebfb21ab128f73540d09a5ecd58983345656c33c77c757faa4f624"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6d724fad-a67b-4fed-8152-f6f98aff6d63/fdf36e0be9ca9a92af106e27f1f9547e/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.pkg",
+            "hash": "5db580ebe00145f73f881ce8ddec1263bc926d1a87eec7fd6209aeb18564c2d3ab415d547a2cbe28fd71b630de3877955e813e5011e3cc39050d2e1c039ea30e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d7a77b5b-4592-46ae-8f1e-9e84b5bbc001/30f37207e7e149cbd01cd0ac33086b41/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.tar.gz",
+            "hash": "6d2d00d319ad496074aab863bc3156d564872ca46c54bf1b3ed59ed755071c533733a863120da5b533e9bbd5843e276bba6a535e2c7f93a57bb9e858f7fae932"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/52fdaa14-c08b-407f-bc7c-091af11f243d/7f40461579aa105e47a19c7745287847/dotnet-sdk-5.0.100-preview.4.20258.7-win-arm64.zip",
+            "hash": "055144b345e3920318477e4eb7e1c14706612beb5dc05bdf97e81ae657a525a769cc364d6671ca3d7803bee67931d120d6e27a6b5960c6e4c227aa4e9f09ee99"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/40dff314-f6c2-4aeb-bfc7-7f89fc8d2b61/79b23dcc8727ab76b7df8872968475fe/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.exe",
+            "hash": "d201ff295c76b41e7a20fef8a79d1a0135d98ee08af472d2e5f565b0163f10a2bf99faccfd27a79ea6e2b0b9089a1aaf4cbb7cf3450975f6ded64b7800ab9a41"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/22e64aea-4ee4-4c98-b913-303a04b89103/adc3fa5461c11e387aa07ab32f513fd9/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.zip",
+            "hash": "45be2aea1c493c42db6f3a69e36a798e436effc686507a52588030cbc8a39b45445fdea85759f7b7f53ab862b4341da19ef9be1fe0519a4ddac02b2d057a38ed"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2b51d5f6-c84d-40c3-bdd1-518012126a14/b48309f76e99b94c98d3a7b84a851013/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.exe",
+            "hash": "f56f11baee88e4706e049e31c64007bc7df1d8321c2b05c5a8281e6ca039d60b48422cb3a28463d280c0a458f3f4e2f9c10717dcce26d2e8980a27ecfdbf355a"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7255fb86-edeb-4ce2-b1fc-aae124e22d76/bb5b9b8103346ddf78b9a4c17c006b80/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.zip",
+            "hash": "a64bbd3f0a6197bbc004c1845bc43f02595d5682839202e17146ec040727f920fff9a1f2866f65931bc9d5796f663c01ab3282418d4b72e5c7a217324e5258bb"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.4.20258.7",
+          "version-display": "5.0.100-preview.4",
+          "runtime-version": "5.0.0-preview.4.20251.6",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/76bea762-22d3-4ce8-a3cf-64276d4b9aca/74a7bed0b9e67a11cf025115c52506ca/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm.tar.gz",
+              "hash": "912f33feb15a00cc7d983e2ed7c42750de013f072e5c6f0162410cca5b2aaadb146bfd09f0f4cc7c90ccaacbc5a5301bc91cfbd964312d3e44d5ff6c944baf64"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/adb3ed49-26af-40a2-8df3-1460b178e55e/01187433dc24decf562d90d4bb2ce058/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm64.tar.gz",
+              "hash": "36e13d6cf4dce12d5f5aa6bf4fa903a2bbe1b816b896ced4ae388514a3ae7a40fdbd918893e7cacfb3f8c8e328995c5c0cce49973785e05568b00aaf6eafe9b6"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/02c5780b-df7c-4b37-a936-10d5d91259f1/7222fd36139fc536e795f7341fb0700b/dotnet-sdk-5.0.100-preview.4.20258.7-linux-musl-x64.tar.gz",
+              "hash": "2da9779628928b896a4285494349fa55efc987633d918d2c136017db6c4179f9ffbce871d1840bacc2c9e06dd54023bfcacd1cc51fbbeb2eaf1ff2cd175a91c6"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/473651e3-55d5-4e7c-b255-2cbe11358eea/6b6f33d86ee00720b36a7c34200f4d0c/dotnet-sdk-5.0.100-preview.4.20258.7-linux-x64.tar.gz",
+              "hash": "d84fc2795ae6128299d318485a5e9ed8717f38aff83cac57ed9baa95785c33db7153e1d44aebfb21ab128f73540d09a5ecd58983345656c33c77c757faa4f624"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6d724fad-a67b-4fed-8152-f6f98aff6d63/fdf36e0be9ca9a92af106e27f1f9547e/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.pkg",
+              "hash": "5db580ebe00145f73f881ce8ddec1263bc926d1a87eec7fd6209aeb18564c2d3ab415d547a2cbe28fd71b630de3877955e813e5011e3cc39050d2e1c039ea30e"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d7a77b5b-4592-46ae-8f1e-9e84b5bbc001/30f37207e7e149cbd01cd0ac33086b41/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.tar.gz",
+              "hash": "6d2d00d319ad496074aab863bc3156d564872ca46c54bf1b3ed59ed755071c533733a863120da5b533e9bbd5843e276bba6a535e2c7f93a57bb9e858f7fae932"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/52fdaa14-c08b-407f-bc7c-091af11f243d/7f40461579aa105e47a19c7745287847/dotnet-sdk-5.0.100-preview.4.20258.7-win-arm64.zip",
+              "hash": "055144b345e3920318477e4eb7e1c14706612beb5dc05bdf97e81ae657a525a769cc364d6671ca3d7803bee67931d120d6e27a6b5960c6e4c227aa4e9f09ee99"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/40dff314-f6c2-4aeb-bfc7-7f89fc8d2b61/79b23dcc8727ab76b7df8872968475fe/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.exe",
+              "hash": "d201ff295c76b41e7a20fef8a79d1a0135d98ee08af472d2e5f565b0163f10a2bf99faccfd27a79ea6e2b0b9089a1aaf4cbb7cf3450975f6ded64b7800ab9a41"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/22e64aea-4ee4-4c98-b913-303a04b89103/adc3fa5461c11e387aa07ab32f513fd9/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.zip",
+              "hash": "45be2aea1c493c42db6f3a69e36a798e436effc686507a52588030cbc8a39b45445fdea85759f7b7f53ab862b4341da19ef9be1fe0519a4ddac02b2d057a38ed"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2b51d5f6-c84d-40c3-bdd1-518012126a14/b48309f76e99b94c98d3a7b84a851013/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.exe",
+              "hash": "f56f11baee88e4706e049e31c64007bc7df1d8321c2b05c5a8281e6ca039d60b48422cb3a28463d280c0a458f3f4e2f9c10717dcce26d2e8980a27ecfdbf355a"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7255fb86-edeb-4ce2-b1fc-aae124e22d76/bb5b9b8103346ddf78b9a4c17c006b80/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.zip",
+              "hash": "a64bbd3f0a6197bbc004c1845bc43f02595d5682839202e17146ec040727f920fff9a1f2866f65931bc9d5796f663c01ab3282418d4b72e5c7a217324e5258bb"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.4.20257.10",
+        "version-display": "5.0.0-preview.4",
+        "version-aspnetcoremodule": [
+          "15.0.20129.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/44b81693-0122-4498-8a28-d983173862f6/b453ffd36c5410c581b7f6611d87f1a8/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-arm.tar.gz",
+            "hash": "368b5ed98f8fb6a80142564ff705571f037143036ed36ef95f235fa67c94fb86038e60601ad1d82a0ee32b2c17fbe33e5cddf358124be30f09ffb452830d5654"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a64a611d-ed13-40e1-a8cc-f7daa3658c0c/58dd8187655361a6f05a798c25321c40/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-arm64.tar.gz",
+            "hash": "5cfe08a85af590d05f1a384938f13bb471b07d85a2572b622bff77e004f95366c9f347fe384a682480d7fe1547aabbadcf8d82d16605dfd8cf4688a3e082e676"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a753d870-1c08-4896-ae66-eae3566f8e8d/cfc75453b94397533b0089bc6e63e7f5/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-musl-arm64.tar.gz",
+            "hash": "71fd4f2cc5e3dcd41821be6a82675ce7f3f83637153d438160de51dce48540aec494ee4907f7e48e952bb05db8b746d357308419e6ea9355a3fd430e7dec4708"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05d52928-7267-44d6-8f9e-f406a0cd76b5/a90fff112297ead1a6801d30945adbab/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-musl-x64.tar.gz",
+            "hash": "8ca2409c6a44d2ad5949d7107b5855ece12cde95b159f6eaf051f9eb991359fc6c47ec146a100e4169c34f1ee5f98de4b2afadea285ee74748f2cd373b0908cb"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/43b35634-52d0-4c7b-a87a-a709397e88cc/ba7e419c0adba58aa249e818e5c9dc90/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-x64.tar.gz",
+            "hash": "4e1fcba63e8ed494e29da789a6f737d59769b5be8eca038c070ec1a26ffb6601a14fae53be9e463e45b36957dd3b2e425d02d77c36d8682a93c3e3d9ef2742dc"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d5e0ebfc-70f0-433e-bd24-e5041b7f1ef6/6ccedc8a001967cd643bc79013357f57/aspnetcore-runtime-5.0.0-preview.4.20257.10-osx-x64.tar.gz",
+            "hash": "55a3c09c2ed29013ed70b25c76f6cf88002a291a6dfb6d0442dd49f6c1ef86ac7667ddebb4907a938722a26daaa6e05f631191857829d39f797ed53ec18f8177"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4264fdc0-8a7c-4106-9755-8d37d80f502c/63d504db620cd095d69d0b05231766f3/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-arm64.zip",
+            "hash": "3e04855b0d57743aee5980969eceabfd95dda5b4554924cd48a9bb6d67598e4b372588fc582485e082a9aca0dc7a87cba6bf79fab24e923b1f2d8292188b9c9a"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b471f996-cc2c-4d21-8a9e-d2d308c964d6/80e04c11d6c26ca9e06763e93686b8a8/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x64.exe",
+            "hash": "e8173192d7a27380b0b8ae1647a07da21c89eaf15a7f2e0ff8389ace9618bb2cfa00a73dee5bdacd0ee77f35eabf51e2d1915d671707442ec45568f3796f4794"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d0dee1e2-650f-49f9-9c11-05711913eff4/639c43205bd858f8ef297d8cda6e9b42/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x64.zip",
+            "hash": "eca3ecb2d6bc2af36a514adb3cf7031c0183a0358d2b4b0092716513faad848d118b619e7f710b90aa0854ffb3b324fe73d4d19f451422a694e8bd4fa95ca480"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2f677755-3ed1-4545-9a39-5bd3207c0e48/c8f1212b509b4e83944a03bcfa23d15d/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x86.exe",
+            "hash": "356b63ad570bf07f08bcc686badcfdecd5a509b04746ee72e359d5fb76ab697937b59986aedc15636fda17702a1cc22e4829a9c8ca7253ccc4754a7c1ac5a5be"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a3cfd250-c211-481d-9871-df7b9dfa769a/d09ce5d0295d467f368d8b6b0e2474a5/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x86.zip",
+            "hash": "ea126d6cb4147e70fb5aeb0c6e52cee6e7ca78eef48975e1fdbc0112557235e0ae16845d51981a4ad8c88443c9d773966d5818d9ae9c22ffc0cafc9d5545d70c"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/55d3864f-c0d9-4a7e-91c4-1e5cba1735c1/4a5ec8eb28c680c8faf22fe25fb77e06/dotnet-hosting-5.0.0-preview.4.20257.10-win.exe",
+            "hash": "9241e9020cf06bc70b44677a6c562676649833edf4edc02e359d0229fa8e28f06ad9ee3294434815b385ede7f7846c4d0abf0d52ba1d80c139ea7ea0555b5b27"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.4.20251.1",
+        "version-display": "5.0.0-preview.4",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ebbde6b8-a9a7-4cf2-ae76-b2c787948382/7a32a40e86e714ac3cab6c777b6b6bfa/windowsdesktop-runtime-5.0.0-preview.4.20251.1-win-x64.exe",
+            "hash": "f720f676df221e74280899e9c58774b97797d91b9dd2bffc9056ce4e8fb14b57026730d350dec03deb4c3755417046aba37800c2943b3a2ac05dd3a3b28510cd"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/62345c12-033d-4103-ae89-df63514bbee8/b2a4bd7488c12b028fab7e1afadd8ae6/windowsdesktop-runtime-5.0.0-preview.4.20251.1-win-x86.exe",
+            "hash": "cecef9c570348f31fe66206726b4db444fd71e24f21c65eca749f483bbe8d8c8cb5b2f701306b1db0f6b477821fb3ab3dc93bee3a582ceb2d3d80e561e3f6a42"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.4.20251.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-04-23",
+      "release-version": "5.0.0-preview.3",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.3.md",
+      "runtime": {
+        "version": "5.0.0-preview.3.20214.6",
+        "version-display": "5.0.0-preview.3",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ca8f37c7-b5b2-450b-9469-b2941861df64/c722ff6e03c6c8f276faf391c7a8bae4/dotnet-runtime-5.0.0-preview.3.20214.6-linux-arm.tar.gz",
+            "hash": "ebcb583f3900dad27555461a0fe2a871d047004d6feba1026d540d3887b3d9f116533d1f3247d90fa943a9d819e6bc78f084a248574ec33e6d57e2079b18b397"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/56f1893f-d059-4825-ad3f-488859fb86d7/022976b07c9b8bfc9e650c95fc3b91be/dotnet-runtime-5.0.0-preview.3.20214.6-linux-arm64.tar.gz",
+            "hash": "392a9550b50cd01b3a33ff67022dffc6827320a1036a923c513ff87a9a4166c85c4a93fbede1608db43cf3083916268aaf4e782842b7618b99d429ca0762862e"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/858f5b65-8b2c-4ab1-9769-7fec5b38c8a1/44a1c0f6131e44f21425076ac295a41b/dotnet-runtime-5.0.0-preview.3.20214.6-linux-musl-arm64.tar.gz",
+            "hash": "91f27c9d67ed88b54f0fe5869222fedd081ed89c227d2fadeebe48228f501b5bf36b98b84b9926eaad6d8a50bd44958e1fc30d0cce3ffb7d3deef6cf7a57e677"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d5f23cce-759b-44c7-a456-a668d855b506/3dd2f633b763236a6bcb7d4bf63f1ec0/dotnet-runtime-5.0.0-preview.3.20214.6-linux-musl-x64.tar.gz",
+            "hash": "bd6ff3556e4096842a582511beb216a91b2576c6b6b12ab668e581d610611ec682bf1c00181a330a0117a068883f043b51d54e8f3fe00a0f1bef49df74ac84d3"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/038fae85-6953-4518-adc6-55038ccf1c33/ccf2b3e7ba7ebe4da8b35c91eede7d6a/dotnet-runtime-5.0.0-preview.3.20214.6-linux-x64.tar.gz",
+            "hash": "459a5aab9dea6d27e15a55f8fdc4e44e6ed05b20c6d1bd9aba4fbc3b9176ffe79d9ae57b7757401e7c4ed0a11e483c6729b8a25f5af8dd6346dbb0fd025d0f2a"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/de092180-43f4-4f89-b72c-a149aa86caf4/d603d2b043ae80556f1239946140471a/dotnet-runtime-5.0.0-preview.3.20214.6-osx-x64.pkg",
+            "hash": "5b8bddfb1406974c5ad328f9689b2a692edefb821d743aa3dd5148ee6a53b93f21aae3d6f781a7a593f9ec3db86c746f72dfe5e48d7fb3299bf0cc782bd42a15"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/933ae6ba-87e0-4d25-86b8-51ae5a7c709e/7849e0ef58f691fce783ed5e00001833/dotnet-runtime-5.0.0-preview.3.20214.6-osx-x64.tar.gz",
+            "hash": "78a6fa0b9bae717c945e58ae04f30a64d015031f9a474e2dbf23e54625f615d55adf377d334b7fb9f78caaa6cab9a6722d78b66e44faf73878185c3e73864c7b"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6a69b58d-7aa2-4b11-b679-762b0cc48427/cf23f3f6a78c36936a486d8d35a3e105/dotnet-runtime-5.0.0-preview.3.20214.6-win-arm64.zip",
+            "hash": "3e50ff8d24154e4140003fbd255f4f746995590bb8b19939025d795a5927e9ce5c9dce11ed51a94f2cb97faaf7724ae11876294c5273087211e3b2952075199d"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/138d840f-5583-4f3d-bd79-05f0ff719cc9/5cfa84f529bf0227427beda07c74d7f7/dotnet-runtime-5.0.0-preview.3.20214.6-win-x64.exe",
+            "hash": "7f9fd0452ef178f6df58e5de619dad7effbfd1985acc4fc6dd718bb26c228dd1df999af2482d80a925fd84e8f22f6f74a38f0d1c801c8417255abd766438d3c8"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bbd5a03c-0a4e-4530-947f-eb4f44eb30f4/34f0574dbe0525a1073e4b7c83c340bb/dotnet-runtime-5.0.0-preview.3.20214.6-win-x64.zip",
+            "hash": "d7660d441063e6eb2a289e9953d9102742efc88d1de73ede25cce0df687b02b9db2b89e61423c5fa90902b2d001e1e81b3ebabaad69815049a2641ba7b36b6dd"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/020c789e-510a-4c61-8614-18f48272cc89/097461f8baa43cc90d1507460cb75ed0/dotnet-runtime-5.0.0-preview.3.20214.6-win-x86.exe",
+            "hash": "72d90cb5a1317e1a9f939f5341fc396368a99c528074d689cdcb6082a60323663ce59f4840f47c94641ce8184195135ca81f2ee6bcad83b34c601fc3b101f1a9"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8d0c54d3-f87b-42f8-904e-ac7a093f3a00/677c2cc203a451eb31cf8a461440c428/dotnet-runtime-5.0.0-preview.3.20214.6-win-x86.zip",
+            "hash": "fdc8c090bf98f481e28d34f0ee0b61400e65f3ec1c1b56fb5d7105e0d500ead7e6afbd34cc0da7682ffcba2c9c5bf2137c9b212543a4688a28de593878924aaa"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.3.20216.6",
+        "version-display": "5.0.100-preview.3",
+        "runtime-version": "5.0.0-preview.3.20214.6",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/58276f20-1ff1-49e7-afbd-fcc6a20acf56/18aacff58da12a91e691036be7ef8063/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm.tar.gz",
+            "hash": "608c204bced8e6c6d315c0e1f418b7c7b9bc794a2c2eb70e1bd55f0ffec5782a1006175f1a50f23e2cd2d004fb22a5bfea61dd7d0f573c2352c71e322163b02b"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/67d8e63e-753d-4900-997f-b332bb63b025/303b7ac855985d077056ef4552f4a4e9/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm64.tar.gz",
+            "hash": "595ed5608ef0c7ba1cae7298ea540b9c165f135afc7126b46e3263de3753f8da6edd6459b5c4a8ec5edb5b00964c5228a2d070cb9b037106260d5b4a9bf8962b"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a9d2501d-4089-4255-9d5c-e94e1ec6532c/9abb1d2998427fa23701649a7b1b1513/dotnet-sdk-5.0.100-preview.3.20216.6-linux-musl-x64.tar.gz",
+            "hash": "4466be190e90ffd85b4dd0a2abc5cacad188ea8f29d7019a2915f98b281a06840a1636f464e6a4a4f871399ca7e1fe00f937cdaa1dd11a27753b606c76c28bdc"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ceba34e-5d50-4b23-b326-0a7d02b4decd/62dd73db9be67127a5645ef0efb0bba4/dotnet-sdk-5.0.100-preview.3.20216.6-linux-x64.tar.gz",
+            "hash": "0ee4a4f3eb082dee321ae4fbd61c3d425225dfe3c0947108bbb2df9f3644e0eeebd0fd4db237cf6b06aa56b0a7ca10eb45c481558ffe4e7422e7e7c4f7369804"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3fa9a36e-907c-4d7a-a98a-e50ad0aa4990/ff63364b94e98687d5933c1b9a50a5d0/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.pkg",
+            "hash": "78cc44d2af20e7278d5cd5dd11ca8cc957c225023555f060e2e54d11a3b5add2c2d9c8012552d45aa27eafcc20c10579fb15180e7c906b1382c583abb4fe2316"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4b8fe806-7a65-43e8-889d-215999715bbf/22005a4af0c34e257e652dbe39d3661f/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.tar.gz",
+            "hash": "341462f073f3642291a65fea8e7af98655aababb7b5c6e0574b7d0e16ab38f20f4bf84cbac24120f1bc22df12e426c4dec5d5353a3f69f748d4f68215dcb081b"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/848d5ef2-81ca-43ff-81f7-6b6e9e38c186/e3462954d7cd7ac54e40d45b9d07d9c9/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.exe",
+            "hash": "ab652850ca80fea4491888c114802fdfd37715805fd297b842dd087828119b17c332adc388c2321de5cb9dd5f091f2fa22ac2c46e76bc33ee0dd377c8a5f1415"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d93d786-1442-4479-868d-5d3b4175b160/b7629a4cd3f95cb0a2d7b202537fdc2d/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.zip",
+            "hash": "f9268b2007e5f7df5048b3e9e3f1edd5dc63d5aa3431b497285cf5c5c90dca93dcc247b3b6eef5966671431d0f11419584ff25c4a8c0b9faf210df61bf8553f6"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ed38b46c-2373-4e81-aab9-18a7f727685e/018f9be726039087d1654b055c2eb641/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.exe",
+            "hash": "7f52de73342dae67ac09d362b87087d2dc6de59e6470ab67065ee95da9d97dc8863cee62fa1d425814aa9ea622e16e02a49cb962295fdfa917e26b6846ea4f47"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/be4d30a2-9cb9-43d0-b5a7-b6ba63d77bbe/f77ee9cd22084283dd23762b23996db8/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.zip",
+            "hash": "bf89fb973a9b37f7ffb6c37ed9ff513bb13f786f7225ab9eaac3ae16a43f90b249881926e1bf020fcdd7db94027586811b21002e374be3fed613424d7e06f328"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.3.20216.6",
+          "version-display": "5.0.100-preview.3",
+          "runtime-version": "5.0.0-preview.3.20214.6",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/58276f20-1ff1-49e7-afbd-fcc6a20acf56/18aacff58da12a91e691036be7ef8063/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm.tar.gz",
+              "hash": "608c204bced8e6c6d315c0e1f418b7c7b9bc794a2c2eb70e1bd55f0ffec5782a1006175f1a50f23e2cd2d004fb22a5bfea61dd7d0f573c2352c71e322163b02b"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/67d8e63e-753d-4900-997f-b332bb63b025/303b7ac855985d077056ef4552f4a4e9/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm64.tar.gz",
+              "hash": "595ed5608ef0c7ba1cae7298ea540b9c165f135afc7126b46e3263de3753f8da6edd6459b5c4a8ec5edb5b00964c5228a2d070cb9b037106260d5b4a9bf8962b"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a9d2501d-4089-4255-9d5c-e94e1ec6532c/9abb1d2998427fa23701649a7b1b1513/dotnet-sdk-5.0.100-preview.3.20216.6-linux-musl-x64.tar.gz",
+              "hash": "4466be190e90ffd85b4dd0a2abc5cacad188ea8f29d7019a2915f98b281a06840a1636f464e6a4a4f871399ca7e1fe00f937cdaa1dd11a27753b606c76c28bdc"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7ceba34e-5d50-4b23-b326-0a7d02b4decd/62dd73db9be67127a5645ef0efb0bba4/dotnet-sdk-5.0.100-preview.3.20216.6-linux-x64.tar.gz",
+              "hash": "0ee4a4f3eb082dee321ae4fbd61c3d425225dfe3c0947108bbb2df9f3644e0eeebd0fd4db237cf6b06aa56b0a7ca10eb45c481558ffe4e7422e7e7c4f7369804"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3fa9a36e-907c-4d7a-a98a-e50ad0aa4990/ff63364b94e98687d5933c1b9a50a5d0/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.pkg",
+              "hash": "78cc44d2af20e7278d5cd5dd11ca8cc957c225023555f060e2e54d11a3b5add2c2d9c8012552d45aa27eafcc20c10579fb15180e7c906b1382c583abb4fe2316"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/4b8fe806-7a65-43e8-889d-215999715bbf/22005a4af0c34e257e652dbe39d3661f/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.tar.gz",
+              "hash": "341462f073f3642291a65fea8e7af98655aababb7b5c6e0574b7d0e16ab38f20f4bf84cbac24120f1bc22df12e426c4dec5d5353a3f69f748d4f68215dcb081b"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/848d5ef2-81ca-43ff-81f7-6b6e9e38c186/e3462954d7cd7ac54e40d45b9d07d9c9/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.exe",
+              "hash": "ab652850ca80fea4491888c114802fdfd37715805fd297b842dd087828119b17c332adc388c2321de5cb9dd5f091f2fa22ac2c46e76bc33ee0dd377c8a5f1415"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5d93d786-1442-4479-868d-5d3b4175b160/b7629a4cd3f95cb0a2d7b202537fdc2d/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.zip",
+              "hash": "f9268b2007e5f7df5048b3e9e3f1edd5dc63d5aa3431b497285cf5c5c90dca93dcc247b3b6eef5966671431d0f11419584ff25c4a8c0b9faf210df61bf8553f6"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ed38b46c-2373-4e81-aab9-18a7f727685e/018f9be726039087d1654b055c2eb641/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.exe",
+              "hash": "7f52de73342dae67ac09d362b87087d2dc6de59e6470ab67065ee95da9d97dc8863cee62fa1d425814aa9ea622e16e02a49cb962295fdfa917e26b6846ea4f47"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/be4d30a2-9cb9-43d0-b5a7-b6ba63d77bbe/f77ee9cd22084283dd23762b23996db8/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.zip",
+              "hash": "bf89fb973a9b37f7ffb6c37ed9ff513bb13f786f7225ab9eaac3ae16a43f90b249881926e1bf020fcdd7db94027586811b21002e374be3fed613424d7e06f328"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.3.20215.14",
+        "version-display": "5.0.0-preview.3",
+        "version-aspnetcoremodule": [
+          "15.0.20077.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ffbb2903-bd07-47e0-aa7d-9264c942cc38/9937a6b2cf97e16f878f4f3feb874479/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-arm.tar.gz",
+            "hash": "d81b656b357b16e9a4bfbf095c0641f56fe5276a0ce587ca8b31c4792f8b782aafc57d4cf97837901ff1dca8f6eaad462ba137967a6c2f36d90f277fbf4aa8c2"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0d7fdf8a-9163-4044-8626-a0e83bf2a4d9/a02834ce1a5f88021e0c764ccef582c1/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-arm64.tar.gz",
+            "hash": "01e30fc2ee685e1f2bfcff9abd862d353796a25757cdc60598060dc84cbce8b057ba070626f0e96385c0a34d00f9e41861cfd12a782a9ea2a253c32c7bca9d5e"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2bbffd9-83c3-4ad0-aabd-0f6a54b720d4/a6b5f14b44aaf5abb6dea3ad9e88b7d5/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-musl-arm64.tar.gz",
+            "hash": "35efa93b5dec1184510bcb1ab454770f577c163967933257bfce56be5596633f6873671350819044b737e4fd6f6ff19d5904164f496ad633068a39efe77070d3"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/20473703-695e-45c5-b5f3-7d307d3e1aa5/e09ef05ba456f3968d5cff24ceff3358/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-musl-x64.tar.gz",
+            "hash": "ff46d723137d1b60717027035ee597ae993bff17a43f88e00fb44e8f271c7267f1e639079cfe03a717b9e42baef84cacfb464b25791165f94573f504d8ce7b89"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76655cff-bf24-4445-a4af-9dbca1f00e86/4366686af0585397f290d27a042a1449/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-x64.tar.gz",
+            "hash": "1839e36b03c7c1da497f8ee6f2b484591513742a8aae897281a4be17f22d1d7ca5e9d877e4b90ab6100136564efc41c47287ef9fa071441f7d2e203816e0f1b7"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dcf33838-366b-45c9-9db5-8ae6d59c1433/afa19a627e073b7f7e26c740ba56f352/aspnetcore-runtime-5.0.0-preview.3.20215.14-osx-x64.tar.gz",
+            "hash": "d269cb1627a175e6d33486c4f8df8873b9af5a67d8f6794fba7b8bc320338bdd2e29872120e0a86ed5f5de081dc87a025d46c0c0b6393b92ee0ede127b061d5a"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/389a714a-d6e9-4e2d-a78c-04e45ed12e17/7cfbdf77fc2a0dc1dbdf2bd0985e5199/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x64.exe",
+            "hash": "7f99511598257374de2f05c9eb2fc2ebfccee6bf1638408106f0ec15b6e8741ed614948f54ed63178d9c4a96439d5be30605a32effc7da1112fd56216efbaf65"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7683a95e-1336-4f8b-a3a0-21f6dab44138/9248f166869d1906a6e37a80e81b7b16/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x64.zip",
+            "hash": "d26caa3490f4a62921733a28a464f049fa812d94b19332c5c4106ac86b044e28a625ce5d966cdcb5ba3a4929845bb2cbf847f95714e4efa253dbc92d16d55128"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f309e08f-d2f6-46a4-92bf-09cc20475884/06fd23949d41b46fcb76e3ee60c3c4e2/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x86.exe",
+            "hash": "cfee7eb241919c56db6b099c768b2835274f4a42a866c79f5dc572c228fa0393e6b8bd0cfbe50f37fcc99bef6f65dec49fe49165ce5a1b4f5fc2c90b10fbba33"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cf56d473-8868-41c2-b86f-14c7b0ae56ef/4c54b358bdb5f86ca77df4a3a79d0f59/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x86.zip",
+            "hash": "1e954e62fe4c64805a5b9b5c3ff1eaf2b5f707b93394da0fcee7f40cdf8425a9457fe8e00336d3eadd060faec5816906fe5df1d333634462659f07a546724af4"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f84dffc7-f825-47d4-aad5-f3af1444ecc1/935d1397344d5179cf210787d6435c44/dotnet-hosting-5.0.0-preview.3.20215.14-win.exe",
+            "hash": "460832918ab1ecb158f5c756e7c6eda468d0b997ec0467e946c6b64977485ab0470f54297164c6f182348eaac77b3b371382024f06f94bd3b26fd49cea5cd139"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.3.20214.2",
+        "version-display": "5.0.0-preview.3",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3d928a84-9d22-44e2-b273-c0ba24d95018/7f168212264a949c0f3799cf450f0a14/windowsdesktop-runtime-5.0.0-preview.3.20214.2-win-x64.exe",
+            "hash": "131ceeae5b4b00baa572865c7402dfd5432a865bf493b46db61f196679d14847b64afee73cffeb3a7d19db5d3886921987d6b5080270ec4ff08dc64d29df9a15"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/39d51d83-8b69-4b8b-8fd2-8ea451fc743e/dd667944896af153df70036bd9323fef/windowsdesktop-runtime-5.0.0-preview.3.20214.2-win-x86.exe",
+            "hash": "6fda214d9d80feec7867fa0d9285400fbc9fde0fc263ab2d00924a4f8386824adfb7be8dd7f6ef17a902a33cb8f68dae1a4486a089d101270eaa09950919653d"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.3.20214.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-04-02",
+      "release-version": "5.0.0-preview.2",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.2.md",
+      "runtime": {
+        "version": "5.0.0-preview.2.20160.6",
+        "version-display": "5.0.0-preview.2",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-apphost-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/44853b8b-53b4-4f85-affc-b98f62167358/0b690b9675696ae8a2f2d4ea86c5de3a/dotnet-apphost-pack-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "979220a6468bcdae67a0886d1ae8b4492b30d2e24ae3795087214c33bee4c368a58febbda7194fa9fed471f8d74e8b3107062ecedd38138ecf159f9ed31ad17a"
+          },
+          {
+            "name": "dotnet-apphost-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/364e6a3a-486a-48ae-9f7e-b6ed36c72e55/9432eb01047c21d2999357dfcbdec0a2/dotnet-apphost-pack-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "14dd10bfb83f20b04306188f86bd75c27c2b39d6f4bf2fe49b2343cfc265c3e71a71757ca2765f79895791d4026cc480f92de938dc127a9fd3224f03060955e4"
+          },
+          {
+            "name": "dotnet-host-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ae67930-daf1-4eb7-9a90-0b119c8c0be4/b1b0776885d0895384bb82e1c9b2205c/dotnet-host-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "8a470a4e0336d563edf447373c40983360f513e5f08b44747c67c851acfb162d5d6c9c427edc67e5c5db3a44f367fc9b64294a8cf115bc9a085b8dd1e6eaf1ad"
+          },
+          {
+            "name": "dotnet-host-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4b5422a7-1b37-45b1-985d-357599a7e838/ddfe668bd25054a0ab0d37940d70b80a/dotnet-host-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "f6aa1db3b7b2ee706aacaef43cc0c4e6872243be7de3afd9bad7774929004c66693dcbcb1b2ccda39f371c20fcc338a2b458a242fe2df195ee1161ce7addc7b1"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eeeea1b9-55f4-41de-b1d9-eaff6f4548d1/84d6146b817601fbd57e982d02c9fad5/dotnet-hostfxr-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "bf04bdd0fa17a3b197da2360d36cad723898fbacca53fc614b0154a9f60c37a1e314daea1291757d187a4a54dc424fcb223572585d516e0e10d4c337d6f6e9c0"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0bc83586-0c67-4de4-9234-b3f25478da34/307c9c79dfac51dfc1e775b00407e59a/dotnet-hostfxr-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "edcddb1da7aaf6c2f68c0a9a0e3a606080db9c9a51150782050ad1153b049cf4f0aa278041cb8c3c40a3e8c12ccfe7a5aba8365ff1e0f942ea1214ef3128b9e9"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6f0267d8-77f6-4677-8c7d-757b100d3b54/f57788735881fd95b90ca020653c6bb6/dotnet-runtime-5.0.0-preview.2.20160.6-linux-arm.tar.gz",
+            "hash": "4c8256f03d3d1185801cb8d58cb456eece964e9d0e87c57ac1ba09316ae0808929f63cb73dc029eb2519ffda7f6204c2c40c154621c2dd02d32164b2860f8080"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7c224d38-8f76-4ae7-808b-c9617fc46d27/26bee5ca707c17eb8afec45acd4785fe/dotnet-runtime-5.0.0-preview.2.20160.6-linux-arm64.tar.gz",
+            "hash": "f06dc6c0166b154d87eaa581691bb8cdbace4c38eed25faf23f21fcad29688d45cc9b6905bf3de9891bcd2ed1ac85e571c799174d480595e6821e7d9ed0fe250"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf5994eb-1eda-49b1-8912-2bd7386b4f56/380f690e7904a32e4b8ce89736458d8d/dotnet-runtime-5.0.0-preview.2.20160.6-linux-musl-arm64.tar.gz",
+            "hash": "ed87ce53b2b22c8e4b407657546182217905e39d7ee43cf9baa31d9598303e1bebddba1f57f77298c6131e413334b58c62254a0c7c7ce27f622367430b1f69b9"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/85a0c2f5-f0b7-445a-84c1-bfcea1c94d9c/7c0808ed36558df5487b6196967344e8/dotnet-runtime-5.0.0-preview.2.20160.6-linux-musl-x64.tar.gz",
+            "hash": "f8dcf9f498feffbca4b0649086cffd298cd98189b2950c32dd52b07179b7f33e1acfe14ae59a266502a3518089ca55f224e007628d16194f94be7dc419c1b2b4"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f98746fd-2d36-4181-9978-e373a321e247/7cf737bead76e4b09b309fa7122cd134/dotnet-runtime-5.0.0-preview.2.20160.6-linux-x64.tar.gz",
+            "hash": "4454d8cb79f9a14ee9f0aa5c6b91a2d26de8e3748add0396f65f59a78b5c96e8ff2fe5bc0156915a7eebcdcb71bfc3b60d7a5cd66d28b96cc043357c9b07f106"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e486a3b0-7689-4429-8c6b-8388df41c14c/3ccd26660a01b4af7b24d77d0f4128b1/dotnet-runtime-5.0.0-preview.2.20160.6-osx-x64.pkg",
+            "hash": "acb3a49ca2f20b320f427951886971ee810cb9e66a1ab525c826dba3fa4defc55ea59547b51855038c9b1f440a856fb99b33c157b64318eed50606fd86d4c0b7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/da039879-4fea-4e4b-a779-2f3c271c0a09/777fc8882d54407f82bf3d0b801d853f/dotnet-runtime-5.0.0-preview.2.20160.6-osx-x64.tar.gz",
+            "hash": "970d045fc325b1f74d1f092280b320a0c800f8632bdf16cc1f7e29a3145135dc22a2a05709bae2ab3c2ed7e7ecaa18253628fe1bc2b25665fe20fb3c9015f3c0"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a26cea08-bc46-4d97-a8a3-0aebb3f135f4/2aece2998f2eb12292bb410912c8cca3/dotnet-runtime-5.0.0-preview.2.20160.6-win-arm64.zip",
+            "hash": "9461a367ea1c550552be08fb09f1eb352793e029bb13073761860ae738b9561d1ed51c2a4892226347a51cc189e6ddd376e09fd27eca973cc5bf8c3a15cd73f7"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ca6db74a-5f97-48e5-9abf-14414e825215/d6f04952fd2bb61d7af4a4fa6d8d0759/dotnet-runtime-5.0.0-preview.2.20160.6-win-x64.exe",
+            "hash": "6d0b38f55014111755982bf71f9cc2d071018e1230279abc3ac2ecebc73ba8d4f7182b97cb35b829cd533fb23d044ab53bc05b04a60e6e480d8e54e826374b3b"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6d7798d7-2df3-469e-a6ff-f3e99c35838f/9aa0b9ada7f2c43524e67c0ead227693/dotnet-runtime-5.0.0-preview.2.20160.6-win-x64.zip",
+            "hash": "db4f24db1e20dbdd0242b8c5730a98612954e28ebc18db655147d80cf4865ecad7ad6a72952750638b4205870ec86eee5a1073fd2f13b98811fc4e8b420f5082"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a82ac5a9-cd97-4a27-a02e-5fcf98be31f2/014f4378b742465f7772998b25cf53bc/dotnet-runtime-5.0.0-preview.2.20160.6-win-x86.exe",
+            "hash": "24373413835460e0c972318b11692b4cbe8e6cb997d108f6ec45d9b0b8af16328ef99e08cbc2b42337c48aee1caeb7461eee06c0c0445ab575b65f89cc2d2d84"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/236c8426-af8a-40b1-b1f7-449971674dd9/db79bdd104621b1e6fde4e334cbb534a/dotnet-runtime-5.0.0-preview.2.20160.6-win-x86.zip",
+            "hash": "ecb6323acbb0dbe340fd11e1a19b339595c26063b75be3a7cbe2cb5ad8dc15e62526d827e7f9e64a3333a02a6c01f49813bb16950744fe589b4e513a9996d5f0"
+          },
+          {
+            "name": "dotnet-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7636e659-2bdd-4a99-82d8-852a76623d7c/c9bd97db81e20d4a6323acaaf8315695/dotnet-runtime-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "a927d064084e0081d8603e8d7d934fbd19768e305f0f9f0c589c2b9902001277ee523df4e928a6dca26304f461a965d5fcd9c75456b267a95053473f92af15e2"
+          },
+          {
+            "name": "dotnet-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e9d54bc7-511c-45e9-b1cd-be7000ebae4d/e9428374b9b96b59cb534ecb7972a08d/dotnet-runtime-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "7cec60a908e3dc8af3805a915894ee39c0f2c18fadfd039b6dfa57165c9ba713ba972710396d36c69a4655cd14b9aea148bf60d9c698057f8e50e750a21dbc74"
+          },
+          {
+            "name": "dotnet-runtime-deps-centos.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/473bf5ec-2cb8-41fe-bc20-7ed3aff24e97/da775dc162abd69f4f56ec3bd5a4eab3/dotnet-runtime-deps-5.0.0-preview.2.20160.6-centos.7-x64.rpm",
+            "hash": "f312459b881887b189e6ccc839bae4a29ec2d5f4520f789fae27e51ff2112aa32afb4fe7160c3526b825ac2a07ce691f810655d17b2f85960b865c2b6e54df7c"
+          },
+          {
+            "name": "dotnet-runtime-deps-fedora.27-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/331480bd-392e-441f-a2fd-7cc44eb91963/4bd8a7444c84cdb330a57e112b378840/dotnet-runtime-deps-5.0.0-preview.2.20160.6-fedora.27-x64.rpm",
+            "hash": "4d29ded139c046d7733a530e1a8e995dee65c0b5b1b8dea4aea5e42763ae0a4f5979a96920856ac1e23b2ee008ab216a54f78d2f29b860572d7deca8221ae4fd"
+          },
+          {
+            "name": "dotnet-runtime-deps-opensuse.42-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/016e84d1-12cd-4936-a395-f59175f315c1/3be52ec84087310f818062c9eddfb8cd/dotnet-runtime-deps-5.0.0-preview.2.20160.6-opensuse.42-x64.rpm",
+            "hash": "c2437ceb83413aebf1505e4018a3077da701159134a2da9b23a77163217178f2e1c8b723ccb416e1ad0bbf81719240331211c031f8ef46e49003b71ddf3be112"
+          },
+          {
+            "name": "dotnet-runtime-deps-oraclelinux.7-x64.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a90a5ac1-a810-4949-9a80-375edb781a20/7446a37848fbfbd71a7a5712fa1b00e2/dotnet-runtime-deps-5.0.0-preview.2.20160.6-oraclelinux.7-x64.rpm",
+            "hash": "64a14417e0402796f6242bcab6306b07da015dd9612280cce068e9e78f40035d4a9ec3a74d06cb03a91e476f6c60a55a5baa9ac3a720320b55f9f92723caaf51"
+          },
+          {
+            "name": "dotnet-runtime-deps-rhel.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8a3a4c2a-2d1c-452c-98e2-f7d311e5da6c/be182c8bab34374882fc9e8983401ff0/dotnet-runtime-deps-5.0.0-preview.2.20160.6-rhel.7-x64.rpm",
+            "hash": "afd2c1b50828c644bc289faf982106a3c753fb46281256f8a4b8d3ef26475838ad3db9870721925117420ef64728fc843e37b8269fa4acb6d133b2eb959f6250"
+          },
+          {
+            "name": "dotnet-runtime-deps-sles.12-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/44284ae1-547f-4b70-aae5-ed4845c062dc/2dc547727ead01a436355f5ef62fa0fb/dotnet-runtime-deps-5.0.0-preview.2.20160.6-sles.12-x64.rpm",
+            "hash": "8e9109572fe21308f202d8cd338773dd52bef7c8c802e2b2c7fa6a6a9265757045a3f328e58918e8208c44a7b412fb67e77896766dc371f8dc1527355333bfb0"
+          },
+          {
+            "name": "dotnet-runtime-deps-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2690fbb-0339-451a-b9d9-2524e5e0f5ca/96b2876bce44409090b0f9f6e857e50e/dotnet-runtime-deps-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "1a59f6efe4de5812c421356118215fd82b9d8e75df3d2ae92dcfaf6a824366c25fcd689db0e2fa1d3a2570e77649e3e750a04842a74fc8aead4805f9ee09352b"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76d622f8-a4ac-48f7-91ee-067a57b3f1fa/c806d99c72e3df42e804d42790fbde17/dotnet-targeting-pack-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "247d7c0da1ce5e82e56965e82cadd03cce22ec32e6a041ec3a261be707718350926389c58b6843a61e08694d8c41c152182593d132ea7632fcd9cb91e4cef267"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/123647ba-a2f7-42b6-b0ab-71ca13eedcdc/821eeda51d3c6f1f10d5131ac75eaa9a/dotnet-targeting-pack-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "21de82a79f02465896de9b10f487354931f3e9f207599180fe7bbde28516b5b3c0dae040f0028207c37e45848cd3cbbd6f18a1e32362ae5f301cc675cfe33670"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/52431976-cd2a-4c7a-a8e3-7b5f1d76fdd8/f8c4af99f9c02963a5d152bd65017013/netstandard-targeting-pack-2.1.0-preview.2.20160.6-x64.deb",
+            "hash": "483d0091f151677d5407fdd9fd718a606ba33ed25f895f4b76b45b020e2434b9b4f8a660783b031b022a1d1e6d877c5e8159121915c0e0fd158081afb4d5727f"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/41364085-9a79-4cbf-ad99-ad7fbe075196/4e0965ed7e784897e433af673b85ea69/netstandard-targeting-pack-2.1.0-preview.2.20160.6-x64.rpm",
+            "hash": "25374b1deb14bba20d1b97ab557274aa58278957d271c046a7ba41f84a073aa6b7c5bfac5337f7466f3f0b562748fa512a8c56fd8576870bb6ee32fb4a8dc759"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.2.20176.6",
+        "version-display": "5.0.100-preview.2",
+        "runtime-version": "5.0.0-preview.2.20160.6",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c35cd82b-2b99-4572-a8f3-64718bb62ad1/c7e67beb45f7819545e1a62139ed96a7/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm.tar.gz",
+            "hash": "0d11dc0dbaa68278021491ee1327a736e353be6891de48e276283f9ea74ccc171250df170f5981737e9826bd49fdaf80d0808dd7c1c939e3defb2cbdc5dd32db"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f87574ee-c128-4e91-b436-68c99d801daf/b296bea9d987a4edaa71df47cd2e7aca/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm64.tar.gz",
+            "hash": "53cbf213e2e97b909b256d931f061178f26e5647424f144266d4af2e12d6443ef7398207a8f4e6f220c61db9ce49de3dc09d88417288a6a61d9b05e1def6b279"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a759ab8d-26fe-4862-8b02-788f6ec47ede/7c2ca8984e9a0bfef27ab95cf28379a1/dotnet-sdk-5.0.100-preview.2.20176.6-linux-musl-x64.tar.gz",
+            "hash": "83b65c6d95d04213685761cbb36a65c1b4c2a2991deeee421446f8e5956acfd1275243f3bd1ce95726b8564d7d88c6a48aa1f7f728b406a385c41e506fb13d29"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/727a5825-d29a-4f45-beaa-053399f8b5ee/5f15827ceb4851ef87a008f5de0acf6c/dotnet-sdk-5.0.100-preview.2.20176.6-linux-x64.tar.gz",
+            "hash": "fface8ff5facdec10d11f8249b426a71cd5bc17aa4e4b1fbe85f4a462e55bdb648a456973a3257f0a700be1aeb0f9bb41639ceca12c2e67d1571e4544ae62bd7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3ce4af4f-f5d5-406c-a065-2ecc9bcc5fd2/353affd22a0727b476998312738ac35f/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.pkg",
+            "hash": "895f31e3c46081f66a24704a4483cb76abc2ae2c4c790f134650c02be9aee7477a0e0de2329e36c05b6267bb19260e7e32b5b8b7b7a9be36d9d06972d43db7ab"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5046ce80-6398-4173-9717-e2947f2585eb/841aad7475e8c9b78cbc50e3b8d35dae/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.tar.gz",
+            "hash": "7359a8ae35265c47a8e893e6b32f13063e4d139ad4a9e89f4e08e01acff2aa92b32d40c19e1b117b5e24e2eda132ea46bfb4a9ad3f409c7b60bc70f9a97a492f"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/00296620-d967-4ae4-af29-bef9b0019970/4cdb51006f22059c14913bdfca57f5a1/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.exe",
+            "hash": "c3f511623b89662a95ce08ba00d0b7f588591eed62fd0c205c4916c8e540fdbfd9dead85da31b50aa085702dc5dbe98f8629f99ff4bcc49a2e115d48b7534d38"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/023b41aa-073b-491e-93ac-7e726fb81bda/b06f72654e32d1bddc941ff932f32c59/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.zip",
+            "hash": "94ec391e19232abc419e4327bbafe9e1f1b363bdda8c280da97f8cdc9f511747d3add76e0fb9909080c554f5acc61ebf7292d84ec5a81acf22d49760bf36ad72"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2f9d9ebd-07b9-4c88-b4e6-8cff9d5be760/ac3e76c14c15cf0999b3b8d2bb3a904a/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.exe",
+            "hash": "d9a4241a782913a0e371acf25744e40f16a469e19b80054387c1eef911aceb7d71794910a0e9629d593b0d16371a7d66ea19651701c6ce1d8d1db52f036774d9"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c1a5bd0c-6236-45a9-bda4-fb9e2007e770/0a078520e350f64a92d5f97ee9b89a9f/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.zip",
+            "hash": "0ea68fa63d537252436cd2721a2b0fbb256549b5f0d093536d5aa1692697fb17e62df36a22fd19daa47f8b20bbe1ee85aafb5a8c47298c45ddafe27e56223fc9"
+          },
+          {
+            "name": "dotnet-sdk-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d10bf368-79f0-4635-a04f-93301569844d/a3991083c98a2cc5ba1700e0048aaa88/dotnet-sdk-5.0.100-preview.2.20176.6-x64.deb",
+            "hash": "d3527bbea25ce0aa6eeab39d997dd8c2fba8a7b0c9b07d8a523205edb4dfaa5bc4c15c018354c4f812a5c26592f3becaca80bbb793d9535ce49a0ae8c2fac832"
+          },
+          {
+            "name": "dotnet-sdk-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ce4434c6-31be-4f7b-9c42-3c43a3e3a9cc/becff13989b2a126637acc2692e223cf/dotnet-sdk-5.0.100-preview.2.20176.6-x64.rpm",
+            "hash": "31f3ede22c545003bc371806eab559bba5c5d5ab1816a5e9516cc80540be77997094db690ba0493e8b3804c6fe474995d2a5ae343db28961b3e60651fada8350"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.2.20176.6",
+          "version-display": "5.0.100-preview.2",
+          "runtime-version": "5.0.0-preview.2.20160.6",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c35cd82b-2b99-4572-a8f3-64718bb62ad1/c7e67beb45f7819545e1a62139ed96a7/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm.tar.gz",
+              "hash": "0d11dc0dbaa68278021491ee1327a736e353be6891de48e276283f9ea74ccc171250df170f5981737e9826bd49fdaf80d0808dd7c1c939e3defb2cbdc5dd32db"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f87574ee-c128-4e91-b436-68c99d801daf/b296bea9d987a4edaa71df47cd2e7aca/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm64.tar.gz",
+              "hash": "53cbf213e2e97b909b256d931f061178f26e5647424f144266d4af2e12d6443ef7398207a8f4e6f220c61db9ce49de3dc09d88417288a6a61d9b05e1def6b279"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a759ab8d-26fe-4862-8b02-788f6ec47ede/7c2ca8984e9a0bfef27ab95cf28379a1/dotnet-sdk-5.0.100-preview.2.20176.6-linux-musl-x64.tar.gz",
+              "hash": "83b65c6d95d04213685761cbb36a65c1b4c2a2991deeee421446f8e5956acfd1275243f3bd1ce95726b8564d7d88c6a48aa1f7f728b406a385c41e506fb13d29"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/727a5825-d29a-4f45-beaa-053399f8b5ee/5f15827ceb4851ef87a008f5de0acf6c/dotnet-sdk-5.0.100-preview.2.20176.6-linux-x64.tar.gz",
+              "hash": "fface8ff5facdec10d11f8249b426a71cd5bc17aa4e4b1fbe85f4a462e55bdb648a456973a3257f0a700be1aeb0f9bb41639ceca12c2e67d1571e4544ae62bd7"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3ce4af4f-f5d5-406c-a065-2ecc9bcc5fd2/353affd22a0727b476998312738ac35f/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.pkg",
+              "hash": "895f31e3c46081f66a24704a4483cb76abc2ae2c4c790f134650c02be9aee7477a0e0de2329e36c05b6267bb19260e7e32b5b8b7b7a9be36d9d06972d43db7ab"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5046ce80-6398-4173-9717-e2947f2585eb/841aad7475e8c9b78cbc50e3b8d35dae/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.tar.gz",
+              "hash": "7359a8ae35265c47a8e893e6b32f13063e4d139ad4a9e89f4e08e01acff2aa92b32d40c19e1b117b5e24e2eda132ea46bfb4a9ad3f409c7b60bc70f9a97a492f"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/00296620-d967-4ae4-af29-bef9b0019970/4cdb51006f22059c14913bdfca57f5a1/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.exe",
+              "hash": "c3f511623b89662a95ce08ba00d0b7f588591eed62fd0c205c4916c8e540fdbfd9dead85da31b50aa085702dc5dbe98f8629f99ff4bcc49a2e115d48b7534d38"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/023b41aa-073b-491e-93ac-7e726fb81bda/b06f72654e32d1bddc941ff932f32c59/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.zip",
+              "hash": "94ec391e19232abc419e4327bbafe9e1f1b363bdda8c280da97f8cdc9f511747d3add76e0fb9909080c554f5acc61ebf7292d84ec5a81acf22d49760bf36ad72"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2f9d9ebd-07b9-4c88-b4e6-8cff9d5be760/ac3e76c14c15cf0999b3b8d2bb3a904a/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.exe",
+              "hash": "d9a4241a782913a0e371acf25744e40f16a469e19b80054387c1eef911aceb7d71794910a0e9629d593b0d16371a7d66ea19651701c6ce1d8d1db52f036774d9"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c1a5bd0c-6236-45a9-bda4-fb9e2007e770/0a078520e350f64a92d5f97ee9b89a9f/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.zip",
+              "hash": "0ea68fa63d537252436cd2721a2b0fbb256549b5f0d093536d5aa1692697fb17e62df36a22fd19daa47f8b20bbe1ee85aafb5a8c47298c45ddafe27e56223fc9"
+            },
+            {
+              "name": "dotnet-sdk-x64.deb",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d10bf368-79f0-4635-a04f-93301569844d/a3991083c98a2cc5ba1700e0048aaa88/dotnet-sdk-5.0.100-preview.2.20176.6-x64.deb",
+              "hash": "d3527bbea25ce0aa6eeab39d997dd8c2fba8a7b0c9b07d8a523205edb4dfaa5bc4c15c018354c4f812a5c26592f3becaca80bbb793d9535ce49a0ae8c2fac832"
+            },
+            {
+              "name": "dotnet-sdk-x64.rpm",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ce4434c6-31be-4f7b-9c42-3c43a3e3a9cc/becff13989b2a126637acc2692e223cf/dotnet-sdk-5.0.100-preview.2.20176.6-x64.rpm",
+              "hash": "31f3ede22c545003bc371806eab559bba5c5d5ab1816a5e9516cc80540be77997094db690ba0493e8b3804c6fe474995d2a5ae343db28961b3e60651fada8350"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.2.20167.3",
+        "version-display": "5.0.0-preview.2",
+        "version-aspnetcoremodule": [
+          "15.0.20077.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30617205-4338-4610-aa52-f15e92f9cbca/e6e9e688f333bab1aeaf8a94ded6b894/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-arm.tar.gz",
+            "hash": "f3397ddab68b19c0fb479835a98275315250c09ce0e2445d322fa743327bce3fd21580bdd6f480a650d9f0019afdc04df68ff689623fdc6b367589c840ac6c4e"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/75836796-02cf-4fe6-a3ea-e80aca657853/6ae8b11f79026141b47205cbe22fb549/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-arm64.tar.gz",
+            "hash": "d8c08a4b104b1d9aaf7c88e09c48cc2b17af7fa218c895d6dcbd9bf5c3afd2560ff8d647389ba7d8d5416e178897e128bd14c3f4598e821beb3bb8964dc862e8"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9ed6c92e-e82a-4b9f-8241-f589903bb9d2/4328a009d8296b949a9f5dd845e42cfd/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-musl-arm64.tar.gz",
+            "hash": "3d40c20c865dc7a686cad0f30810052387222f5840e81a3b1f352294722335aa44ca29b62106f8161790c7a92f663a934197b5890d641cacc05e886d76f1f7e7"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05b6fd6b-3233-43dc-885e-6f25b1fe15c1/7834ecd7688f9e258ce78fbf942f0fb9/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-musl-x64.tar.gz",
+            "hash": "029ed32f8a7dfdb258438177b7fd40c187830db35b3d973dec296d8948f99d30a74269c45d31876c9b4533b8d7b6af65dea319299bd9a7081c6881cf026274b4"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/169871b7-ce8f-4518-a342-209f98342569/4bb2abeecf4b064eac907fb28f96b5ca/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-x64.tar.gz",
+            "hash": "c155a94b463020f413b9cc6650219b27c08f331f9d1926966e4c4471b1a3cc79e199fbbd4747e8ad89bd03d66cd90cbc68a5554c54e931ac59f7508810303327"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b8c4d3d2-b298-481c-8058-2f297c679be7/77e5e16c704720a52f89d39e676a3e7c/aspnetcore-runtime-5.0.0-preview.2.20167.3-osx-x64.tar.gz",
+            "hash": "774911ba77a3c7868a87ba34784f71f3ff7899d806e1cc1d7e1f5d53bcd7d9031addf75d062efbc5f8a5f38506c09ff8ae17deae191c8b8dfcb708a9b28a4fa1"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fbe8e0a5-7d9b-4cc4-bb16-7166ac5c8caa/3dde80bb4d0e312a418d20ba459b2a88/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x64.exe",
+            "hash": "ddc7128e48440faced3081367f506d9b85dc26ad2f3b2655ab5059769702762fffd36efe086d3215be21fbd44f8fdb0118776322a0de53ab58ead006b282e426"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a0bf9c39-d15e-4957-a7f2-cdd7aef660bf/d171c3c8ae27d6887eeec4e834f79234/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x64.zip",
+            "hash": "559adef282a0f5f70986a27672bc209278791952307cd0442f85cb249ee330ba3998cd4fd57333b057f1cb4149ecd2c1036db09cb8af78d6139ed45665722548"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b87565ce-850f-4406-813e-d38911d6528c/5828bcf354e2d7de213b097077e37ead/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x86.exe",
+            "hash": "de1ae921ed53d01eed636cde1894555d077d97299d3736416a4e861216c47ffe90e19bc3634431addd8e8c96b057fe8c79847c4ab6fe862ed96daaa2348c838d"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9b0aea06-9e28-4fc0-8a47-5d999a6d2589/7e243fc0b1ddcc61a971a7f36a36a2cd/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x86.zip",
+            "hash": "cb9c9a0b15e514fc8c65ef22e56eec4a82b1d95214a997c2d353f6312df6602086968e057a60ac1f5fc18d9bdafa4cad2975cbbc5bed38babe9531f064dcf0d9"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/450b65be-bd49-40d8-be9a-627dd060e014/b5d03d57ae4a0f489a61514f7f328beb/aspnetcore-runtime-5.0.0-preview.2.20167.3-x64.deb",
+            "hash": "5f0445df666983228431744dce9919523952fa4ce3a4fddd41bbbfc907202d6d9a39cf52b1f5879b11e0bce9a820a415028757a2ba803e694e90357d04993b2d"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c56b28c4-4af7-42d9-9951-389d50d6704b/8369cd45ef688c8b9c2e05aee0c5df25/aspnetcore-runtime-5.0.0-preview.2.20167.3-x64.rpm",
+            "hash": "346303c4384afabf5367b748415721ed9262e3af7b1ed0de62ef453161a69f35a553fd66e38c18e06269172870a799bb9dd1818a9abef9cd0afc06193a9a06ba"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.deb",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4fbbab52-c028-4a68-85a3-158278c82006/ee9fda837661283d82a78ff1a6ad4ebd/aspnetcore-targeting-pack-5.0.0-preview.2.20167.3.deb",
+            "hash": "3b1c444f0e0e2adbf4f338c183ddd631d6694c91118de30c2d879ebf1e4b00b8a8a0afb6783c7cc31b3481d5a183a9151234804d6efc88b3b47061d6ecde2ecc"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c45beaea-2f14-4ff6-bc9a-a1a3e7260055/b1f0a2d352cfab9de6bbb3611da00a99/aspnetcore-targeting-pack-5.0.0-preview.2.20167.3.rpm",
+            "hash": "c6c0c92ec89244ff10daa92e559746f2e3364659c343e318bec64c5dc4f3c4475dd6c67d33e7d0de90c751f9b273484d4703583980c50e0f3f79a9728bf72603"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e563b5c8-380d-4ccc-8e5e-272c6cee6520/66a77e469c68453714dfe13a281b89a9/dotnet-hosting-5.0.0-preview.2.20167.3-win.exe",
+            "hash": "d087a4e6c25608bb384e032cc1cd37bf8ea420fa2f249f5279755cbda9ca6b6c8f3ebb7cb7bd731da8440d758aae2f40ba7a5097da371da1035cb34e66076b8a"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.2.20160.6",
+        "version-display": "5.0.0-preview.2",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7fac4640-23f9-4e48-bce1-988292457ece/c6eff69e2d349a94794825a651657442/windowsdesktop-runtime-5.0.0-preview.2.20160.6-win-x64.exe",
+            "hash": "1b083768f30518cd63748a026c19d2624324f4438c4c00118d241d2b6bc5236cf0308cb366938dd748d68d3956091ab996fc3267666c71d70827886c7054e4cb"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db134090-e6c1-4354-94ef-72a8bf42b6d6/c33b7f134c8778107d58b70aaf17af24/windowsdesktop-runtime-5.0.0-preview.2.20160.6-win-x86.exe",
+            "hash": "4e16206556e3944899807bfd914962e9422b5916dd794bb67bf11997fbed78525e20337f0029f66f01687b17492d97feb5f93b317c09d12a23fe6a37554184ce"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.2.20160.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-03-16",
+      "release-version": "5.0.0-preview.1",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.1.md",
+      "runtime": {
+        "version": "5.0.0-preview.1.20120.5",
+        "version-display": "5.0.0-preview.1",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-apphost-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/34382598-1e4e-4749-91e9-3560aa47f442/98fbae8e122b0eeae86d83ec58fb04b6/dotnet-apphost-pack-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "ed117b0c19b53641c960e16f028c1fa17fadab377ffb7fae6de75b8d23f15ad22f8f5f124093a723cb3a2d7877963b4264a316aa3ca6140feedb4f399050b1a7"
+          },
+          {
+            "name": "dotnet-apphost-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/589d3958-8943-4454-83cd-210fce321f1d/8c3a236db7232b77cb0c8802f0e7cd30/dotnet-apphost-pack-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "6ddc9e4cd7ca7bb78fbb9d88ba28acc978e4a2abf7ac01a82b0ec842c51df63679591cde194e3ea28e1655054248c044c2d6f0e0cdcbfbc85f60586f250c6b12"
+          },
+          {
+            "name": "dotnet-host-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9208ba47-f1e0-433b-98b2-b5b088cabc20/cd0c47fb9d317eae9425e34220b7c3f5/dotnet-host-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "350f664500eda05fbd207c3260739291b7ef5aca24f19d9de4d0126d843805de59f6774c75b55727f93f4a4bdda64ae6333c7e41c17a97671f1b2b5e5803492b"
+          },
+          {
+            "name": "dotnet-host-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6b2e16fa-3c9f-4b7e-b93e-674740f6d5bc/4733ba774c769f54cfebc6eb26fa7fb7/dotnet-host-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "aafb470c8f29a4db82f8fc36f3a5b840016c6e87e11de12b606127f931328e72a6fb193b6164cf51850bf6206e314dfee6f55f74968f7590ecdf09ff6d0a1c9c"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/62b018ee-b945-4668-8568-d7efdd642347/a9b9be49357574955f1f0e0c8d652f0c/dotnet-hostfxr-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "605103f3ed2ae03b4d32d65102e84d3ed363e5ddcaaa72caafd9c08885e1317bc76df499e05fa7ecd29f42e3dc52f307400c045028467a52c7bc786479bd6b2c"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6ea43576-5e32-4bbd-b209-7367e75bce14/1f3af8f6c5aad98a6340abdbd95f7876/dotnet-hostfxr-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "e6592b38ce4cbbe087eb0075990e7b3d9c7ed6aeff5d5164e86b0e6468d4a0c9af3ab67a5b1880354131dbb219c49b8e434fb19ebdec6645a727c9c3c711b2c1"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf01eb4f-b9b4-4e31-a68d-6b7f4af49562/0eab2711796c422875dfd06b1c650b5b/dotnet-runtime-5.0.0-preview.1.20120.5-linux-arm.tar.gz",
+            "hash": "4dac1fee28b385c4e9fb133eb5ab7cf281f72c99d8cae3ba1f1b8b077c9424878da4a6d45cc72a3c09e5a37e1c93ac2f78dcc902838ea9f9875848dca78b74de"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/92e433ed-d058-4e45-bc13-3fe6b36c581d/a167eef99a3a52cc68d64801ab0ed1dd/dotnet-runtime-5.0.0-preview.1.20120.5-linux-arm64.tar.gz",
+            "hash": "bac5b22fc5ad2b633d650fb779e37b29339cbf2a4a764583e58927e95d9ac627f75e532e45ca775ec94859580fb865431abc36efcf7aaf3c11eb373a607e0e05"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bdd99baa-336f-4a86-adbb-48d34061ba89/65eeff3091374af37a30ac54444ffb17/dotnet-runtime-5.0.0-preview.1.20120.5-linux-musl-arm64.tar.gz",
+            "hash": "8329ac14d78f119ab905d8770f52f0ad7b17a8c6a0c880618318aba1106fbdb04a3f7769c76708c5603101c575acfe401df002777b5ca8e4ea7a0e3604cfe05d"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4ed97b16-e142-49e8-aaf1-e93b875031eb/870ed7cdbd0e4da3815de83466dbe0f8/dotnet-runtime-5.0.0-preview.1.20120.5-linux-musl-x64.tar.gz",
+            "hash": "a6dcbfc86a65e1c7fa58155df7255c5bc8387361501dac79827f98c92146194b18872dbf2d6c75402ffb08bf7b8111601733cfb20edc8f1e037e108f5b127042"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a1965dfc-2402-49d2-b36b-f48530926905/ba965c0d696396d38315e06da03b8ebd/dotnet-runtime-5.0.0-preview.1.20120.5-linux-x64.tar.gz",
+            "hash": "488f96949f8835b99a688a6ff1699702f476bfd12d2aed5063d89ceaff801fd63e77160838ea57ce9b97f0770e29233e271948f69c790ef5daaa84382ab3d2c3"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/777eb5e6-abe3-4bc0-a19e-22709b26193a/f8ae123ccae445af01d8747616bb6893/dotnet-runtime-5.0.0-preview.1.20120.5-osx-x64.pkg",
+            "hash": "ed395dab0cbc6036cac52d9c4cc269558263bfe86f49cb36971c130960f6374ba8834ba25b5de1a2bd7cf34d94cad56136ee69c486a26c8d9a4b2cfb0c1585a0"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/64e79ce7-5064-4925-83c3-15efee6a49ce/ea6c15edbf449799c6b4c56fa211f780/dotnet-runtime-5.0.0-preview.1.20120.5-osx-x64.tar.gz",
+            "hash": "934eed60b76428a8a16cfe4dd46b72e39a0d413a8155072514a409957a099318a38ffbd2c08330d94fb8d5dd0176d502cfa6c3fb0d82e5908aa368b476b988e4"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3e5b6a1d-b739-4885-8a6a-96cc0860240e/1d316a8ced559ff6304fe5c4f0b4a84e/dotnet-runtime-5.0.0-preview.1.20120.5-win-arm64.zip",
+            "hash": "18fc835f51f23d090460b197f08b3262386d9b9037cac93440a6311e65ec77558e15a52f7b9e5514ddb2f1808b736bf379fcd5bfa99e424024ba2e103e49554a"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b17fa329-bb11-4dab-8998-993cf4c7c5b3/3beb0227b41619ed42e38e99fdf072a1/dotnet-runtime-5.0.0-preview.1.20120.5-win-x64.exe",
+            "hash": "cef89a83d64aa4ff9b17549439686b40527a0b1e019592b83bb46c641060cfe583fb8889b0ae9ea009aead27673082f26776690685f08798f35e9e6363a391d1"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3fa0154e-0d31-4182-a548-30beb70d3ddf/0dd379104b461fdf4b310b479e62ea95/dotnet-runtime-5.0.0-preview.1.20120.5-win-x64.zip",
+            "hash": "6c3afe3b51b85b53a03b448d6fe122a5e7d7da60d904b10040e99a218092e2632ea25bf58b5c9a3cb40151c41ec0fad158ce3487265df4d7eae67e3768408fb8"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1cfbb1b6-2a9f-4d03-9926-de56e7601534/e030d924094d5f840a0260e0c33a205e/dotnet-runtime-5.0.0-preview.1.20120.5-win-x86.exe",
+            "hash": "09c5ef8a4f4fa7e7437bc870f47f7e2375ff52b57560076b5f41c58205071b3db478c1779baac02a2bd633a28ee3878634da05bc50945145a7a31244e6203782"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d81db672-e51a-4691-943f-2c513cf41ead/4e1a4ae6815c476937334467b7d3ea8b/dotnet-runtime-5.0.0-preview.1.20120.5-win-x86.zip",
+            "hash": "09006d52e8d9f95714c3a2a7a8523f08d4bb44ea99a04db2a8432d986c39b871fac79ec8419727410a7814bd21d64f7282595fcc3db1df5262f8de2c9aa0f916"
+          },
+          {
+            "name": "dotnet-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/edbaf09d-5d01-4b21-97c5-f3cf75bba5f9/cbf40693a286fbc5126823c6042c7b33/dotnet-runtime-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "3f5bcd7c487532caca918ff433eaeeacb7339a87019735285b93546d7cbf0d64825007cb8cec9e6d7923f810b886a812238cc4ada2dd77b7768c61b367d423d4"
+          },
+          {
+            "name": "dotnet-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/465089a5-3f71-476b-b611-1b9f41bdec6e/df51cc884314a400ad65f32e21ea5d78/dotnet-runtime-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "49407155f0dc672150464ca20dedc87e6085090426fcc65b57b5f99fd255ad951d5adfeede8868762805ad05a4784c51f4b957fd802cc3544e9c0580e50686b6"
+          },
+          {
+            "name": "dotnet-runtime-deps-centos.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0f07009b-1ccd-4c98-8d19-bd8223912798/e988b9e568c6ef57edb1327b29ecab4c/dotnet-runtime-deps-5.0.0-preview.1.20120.5-centos.7-x64.rpm",
+            "hash": "12950ed76f3f352f4a7b8fc8cef6320e4f0968ee5db0d67a8f57b66ff3ed44a46d92f83856e8e55dbe601136d5c80449dd75636942651848bcaa0bf098639747"
+          },
+          {
+            "name": "dotnet-runtime-deps-fedora.27-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94b6a141-63b2-4e5e-b38e-ff4b02a6f20f/db41939e5e796b9049390ba679bca686/dotnet-runtime-deps-5.0.0-preview.1.20120.5-fedora.27-x64.rpm",
+            "hash": "c4eae900802004f63c076abd5d2eef841f19bd04c14983cd9576febde92d9b76a0f4d81d9f6c5aec32e72652a8ff88eecba974e50ed17999073954ca75ac8c6e"
+          },
+          {
+            "name": "dotnet-runtime-deps-opensuse.42-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa5d2001-25a1-4716-af60-0a7ac450019c/ff3f7336144059d8839f2a09cb952dcc/dotnet-runtime-deps-5.0.0-preview.1.20120.5-opensuse.42-x64.rpm",
+            "hash": "20ae5fc88c113047eef5a65bb86ff2f4a663acc2466451de66fa758c66213e89cb15c31bd0b5c33a6f0a51ab766dc94ccdb7275ae6cfad6e615f2790d0c822fd"
+          },
+          {
+            "name": "dotnet-runtime-deps-oraclelinux.7-x64.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0c651a3d-1fc7-4d05-8949-4f11709de28b/66ca7ddcff2677e22443d63634992365/dotnet-runtime-deps-5.0.0-preview.1.20120.5-oraclelinux.7-x64.rpm",
+            "hash": "d4343571ebd7cb391c4a87320817880abf70375ce1f3a633c2549253ff891746cf209c13a25f1c8b44f6871a044c248552682f553b3dbf63d95ccd138cb86eac"
+          },
+          {
+            "name": "dotnet-runtime-deps-rhel.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1caee7b0-4ca5-4bf7-981e-8d0b85d3dfd6/9b03a14654d00e7604eadd8675aa3fed/dotnet-runtime-deps-5.0.0-preview.1.20120.5-rhel.7-x64.rpm",
+            "hash": "4352bd9d2f1154167493c27a16fa6cbbe4b0e0956497951af86c4ed3643502ac811422cd65125add042756b78ab5498120d4bec1d0948e99bdc042a2ef95589f"
+          },
+          {
+            "name": "dotnet-runtime-deps-sles.12-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ef5e1e72-6b7b-41e7-98f0-7131305d0056/498593e7e06f38d49217c917cb8ea5a0/dotnet-runtime-deps-5.0.0-preview.1.20120.5-sles.12-x64.rpm",
+            "hash": "ac5c52035fe0816909dbe82d562e21d87e6a0f29487318cdf72e5399b51d481b999c06514fc5dc8f082d2a808f62d3835ec80e5b7f7b0639b17f10eeaf92a20a"
+          },
+          {
+            "name": "dotnet-runtime-deps-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/23f9bc1f-6829-4ba0-89e5-0dac90239e5e/37f8056bc3521edd8f4360b04db5dde4/dotnet-runtime-deps-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "cf9934aeae86f9a12003cb577e395ebd11f0d73369f1d964f08ba382de7ab876bdf5af92fc2c28ebae55874bd4785c6fd23607fe68adc639bfac90d37aa44da6"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ae77fe31-a115-4c21-b686-61d2ee5a44ac/82b99cf66d59147022f673e82de4275b/dotnet-targeting-pack-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "cd7225363d24162561e8b14c83f03bfaf1174b7e9c2e2ccb15ef8f2e4ec43208b0314646069a85332313e34b1628cb976d84cdc8fa2b5e9e03a6eddbe1b03401"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/564562cb-862b-42d9-9c27-e1bbf373ff35/7b6ad66ecaa6d398d91614c4848426d1/dotnet-targeting-pack-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "4a429a1397615bdbc420ddbd195b3053c8c171105c92815496394dc43de28c4fb69e0ddb1957c7d973bd8b169c1a424438e1aae5d9ff39f0b197230efabd4eef"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7877ce02-66ba-440f-a7f0-5cad36d94667/5c840bf4c473caf208c1b46b317264ac/netstandard-targeting-pack-2.1.0-preview.1.20120.5-x64.deb",
+            "hash": "1085b801e774bfc9c286a33c11983738febfcaedf611791f34285de8ded20f9ed7046dade34fc6a0278d55ea6715f93fe8492dad9bcfd2d96cef758466c26cc3"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/657a9470-0342-471f-8e94-f1c9c2967ede/d244046503fdaf0c485639df83190285/netstandard-targeting-pack-2.1.0-preview.1.20120.5-x64.rpm",
+            "hash": "39956a7c90516e58c0a6bb19c69f5b4a1ee510042c92715914922b8ea67fd47b484c202c564cb1490bed59ef2f0d0bf2155f8cc7b140c9793dfebee66836d72f"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.1.20155.7",
+        "version-display": "5.0.100-preview.1",
+        "runtime-version": "5.0.0-preview.1.20120.5",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/658cb5dd-9a5f-481e-b481-f80a1ed802b3/9ab953320b89d5690a4fcda48b635986/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm.tar.gz",
+            "hash": "40752321856230ec4be50b3900909d002d28415e3ee6b499c605c922713b2867a736bbde9337c8a7e4e84260a5216f644c15d1660a74923ee06aae75bc62a54b"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/af8bf205-ea0d-47fe-a8bd-fd0a14add533/b926f87ea13147cd9dc80202a464d4b1/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm64.tar.gz",
+            "hash": "022a1f8cf19361f5ac1b7e0635864828266abbaf7bd26955c751a004ab9b5176a71567cba902ced0d2d48265ee0d3468af9ec931c6c9f5375f2d5c33ca14a439"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0885bb3a-60d6-4dd7-82d4-2ccbdda2f90a/6f181788c4f85cc77076dd34b9f8bc05/dotnet-sdk-5.0.100-preview.1.20155.7-linux-musl-x64.tar.gz",
+            "hash": "a346eeda7140c2d674b5a9b1f777d3d4803d340f28466072c5662fcd0c8f002a411f5525845aeefc7e02ada9e22e05fce387f04260f9c3ec2c352a8155553489"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c3d1886b-6846-4328-9692-a0adcdf30959/f0bd5e15b1825fc8f5b0a8166008e08a/dotnet-sdk-5.0.100-preview.1.20155.7-linux-x64.tar.gz",
+            "hash": "e768641ef12604400edf4ba25bd7ea7a2e64c69fa447661b478ceff89f3c77c07ec69f3aa05b966400e88caae4f548a7bfc5a0747f511b5a10e88dd616f73b21"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f262d833-69d3-4aa1-bac1-b32075bebed3/474be39cca68cd46d3dc2cc03188f217/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.pkg",
+            "hash": "b3807b8d3b8780146c801d8ed0bfd878b5bbdae3a6dbf89e4d97f29c2de4ac1b3cb8017e67174221ee8f4cac8a232060bd99e94a614143d4f47682838e227a4a"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1c0e369e-945d-4618-b3f2-499190fb3cd3/369a29dced485be37eecf10728a96382/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.tar.gz",
+            "hash": "243e84d0c1b61bde82c99c603fc2ef78e556850329772a828095bbbaef8f151c90b5474152fca57a25329517a0513dd22f591cccc853cc2525ce1aa10175cb41"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f765753f-9647-4bdf-b66e-da211a949cc8/93c69234b471dad3d5b5d9e54e2fae8d/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.exe",
+            "hash": "a485ace9750f845f4037d7ac7c8cd3174f8db4eb2a8b7ea690a03be611fe5b0a2b3d37a696f8c38ab829e63af7a829a84aec3dd46a88ef5f993daa4dca1cc2a9"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cdd81f5c-3920-4fa6-95a0-3c6267e9c614/705ea68fff8c01e4938daa2a2e33234c/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.zip",
+            "hash": "7f3ac46d09df12788061cfe3fd0ef32eaeeb5656e727f20888113d6028f035b2b724f10b9536eb968c4579b65571c7aba01c8b2b1c5b98ef141cfb5f9c063c91"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0781f119-edf1-4d4b-b0ed-193e30fdb3d4/73ff445ca02c7b21e19bb588228a0382/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.exe",
+            "hash": "d47dbf9e46075050a10a0e78830ca901fd667a2a4691bf5fe41ebb805cd6298d5f558178bd5aa5ad07ca2b9205fa4077a548f1a9060cf82f4ae5ebb87d5e0aee"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dfd7d728-b4d1-4029-a80d-fd032a8ac5dd/f7cd8feff63a4058a2c81bd1b3532fe8/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.zip",
+            "hash": "8b2d7269fe8ae3a70b1776d102c4a84e3fc742be12e548577344146ff9d43193c5addeb847ec0e2c87618ca88721f54787e30d55ea9e970417c8c91e6f0db7f2"
+          },
+          {
+            "name": "dotnet-sdk-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c5a2b347-3eaa-4dcc-a697-737513998d36/17ab4a4271a20a99d0731a3cf924fa44/dotnet-sdk-5.0.100-preview.1.20155.7-x64.deb",
+            "hash": "77f01a7fdddc80cb92521fc73ca618f1631f7c90a5c1d3531f5876836ce0576567bbf31dfa232b88755c46fb230752a393c8344b238c98b7c143654b0d816468"
+          },
+          {
+            "name": "dotnet-sdk-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa0c7248-c76f-460b-84ec-3a89730f2517/d10d65f633f76eb7d0b7330ade514992/dotnet-sdk-5.0.100-preview.1.20155.7-x64.rpm",
+            "hash": "54dfbaa8b63cbd79b7e64f6f9ee11e9d22f789e600bd69eacdab3e4946e1136056a9e17a71dff9f913ef62c80559a3e15e6eb05c988413f5275ab822ce7442b1"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.1.20155.7",
+          "version-display": "5.0.100-preview.1",
+          "runtime-version": "5.0.0-preview.1.20120.5",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/658cb5dd-9a5f-481e-b481-f80a1ed802b3/9ab953320b89d5690a4fcda48b635986/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm.tar.gz",
+              "hash": "40752321856230ec4be50b3900909d002d28415e3ee6b499c605c922713b2867a736bbde9337c8a7e4e84260a5216f644c15d1660a74923ee06aae75bc62a54b"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/af8bf205-ea0d-47fe-a8bd-fd0a14add533/b926f87ea13147cd9dc80202a464d4b1/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm64.tar.gz",
+              "hash": "022a1f8cf19361f5ac1b7e0635864828266abbaf7bd26955c751a004ab9b5176a71567cba902ced0d2d48265ee0d3468af9ec931c6c9f5375f2d5c33ca14a439"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0885bb3a-60d6-4dd7-82d4-2ccbdda2f90a/6f181788c4f85cc77076dd34b9f8bc05/dotnet-sdk-5.0.100-preview.1.20155.7-linux-musl-x64.tar.gz",
+              "hash": "a346eeda7140c2d674b5a9b1f777d3d4803d340f28466072c5662fcd0c8f002a411f5525845aeefc7e02ada9e22e05fce387f04260f9c3ec2c352a8155553489"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c3d1886b-6846-4328-9692-a0adcdf30959/f0bd5e15b1825fc8f5b0a8166008e08a/dotnet-sdk-5.0.100-preview.1.20155.7-linux-x64.tar.gz",
+              "hash": "e768641ef12604400edf4ba25bd7ea7a2e64c69fa447661b478ceff89f3c77c07ec69f3aa05b966400e88caae4f548a7bfc5a0747f511b5a10e88dd616f73b21"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f262d833-69d3-4aa1-bac1-b32075bebed3/474be39cca68cd46d3dc2cc03188f217/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.pkg",
+              "hash": "b3807b8d3b8780146c801d8ed0bfd878b5bbdae3a6dbf89e4d97f29c2de4ac1b3cb8017e67174221ee8f4cac8a232060bd99e94a614143d4f47682838e227a4a"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/1c0e369e-945d-4618-b3f2-499190fb3cd3/369a29dced485be37eecf10728a96382/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.tar.gz",
+              "hash": "243e84d0c1b61bde82c99c603fc2ef78e556850329772a828095bbbaef8f151c90b5474152fca57a25329517a0513dd22f591cccc853cc2525ce1aa10175cb41"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f765753f-9647-4bdf-b66e-da211a949cc8/93c69234b471dad3d5b5d9e54e2fae8d/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.exe",
+              "hash": "a485ace9750f845f4037d7ac7c8cd3174f8db4eb2a8b7ea690a03be611fe5b0a2b3d37a696f8c38ab829e63af7a829a84aec3dd46a88ef5f993daa4dca1cc2a9"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/cdd81f5c-3920-4fa6-95a0-3c6267e9c614/705ea68fff8c01e4938daa2a2e33234c/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.zip",
+              "hash": "7f3ac46d09df12788061cfe3fd0ef32eaeeb5656e727f20888113d6028f035b2b724f10b9536eb968c4579b65571c7aba01c8b2b1c5b98ef141cfb5f9c063c91"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0781f119-edf1-4d4b-b0ed-193e30fdb3d4/73ff445ca02c7b21e19bb588228a0382/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.exe",
+              "hash": "d47dbf9e46075050a10a0e78830ca901fd667a2a4691bf5fe41ebb805cd6298d5f558178bd5aa5ad07ca2b9205fa4077a548f1a9060cf82f4ae5ebb87d5e0aee"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/dfd7d728-b4d1-4029-a80d-fd032a8ac5dd/f7cd8feff63a4058a2c81bd1b3532fe8/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.zip",
+              "hash": "8b2d7269fe8ae3a70b1776d102c4a84e3fc742be12e548577344146ff9d43193c5addeb847ec0e2c87618ca88721f54787e30d55ea9e970417c8c91e6f0db7f2"
+            },
+            {
+              "name": "dotnet-sdk-x64.deb",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c5a2b347-3eaa-4dcc-a697-737513998d36/17ab4a4271a20a99d0731a3cf924fa44/dotnet-sdk-5.0.100-preview.1.20155.7-x64.deb",
+              "hash": "77f01a7fdddc80cb92521fc73ca618f1631f7c90a5c1d3531f5876836ce0576567bbf31dfa232b88755c46fb230752a393c8344b238c98b7c143654b0d816468"
+            },
+            {
+              "name": "dotnet-sdk-x64.rpm",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/aa0c7248-c76f-460b-84ec-3a89730f2517/d10d65f633f76eb7d0b7330ade514992/dotnet-sdk-5.0.100-preview.1.20155.7-x64.rpm",
+              "hash": "54dfbaa8b63cbd79b7e64f6f9ee11e9d22f789e600bd69eacdab3e4946e1136056a9e17a71dff9f913ef62c80559a3e15e6eb05c988413f5275ab822ce7442b1"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.1.20124.5",
+        "version-display": "5.0.0-preview.1",
+        "version-aspnetcoremodule": [
+          "15.0.20055.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/29aa86cb-69c7-40ee-a43f-ed3a88327a38/16f0e2751e1beb740c3f74fbf26be2f6/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-arm.tar.gz",
+            "hash": "0592fdc197b07151970fdc64e3f40d5551bb2d0bc821241e1068ee1446606d5f7569bdd74a4744efa29b86b01a6600807c6c31630c6651d44281ab38767fd172"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/93b0f737-6af5-418d-a801-daaba67561e5/4fea7595d0101eaca86bed539f2cfdf4/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-arm64.tar.gz",
+            "hash": "bc4d66c2c81ba81afa63226444bad97d590b08c35a4f13e2bc972fd11f313bc524286384925c1db0d882acd5ef17ea9cc7715331cfaa2394019cd5bca461d6f5"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7c4daf05-27e3-46ee-a9fe-937dcff55b17/bf88e4f1ee7b47739921e224a83aa41d/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-musl-arm64.tar.gz",
+            "hash": "1b989ff55f0d63be0f512db1caf1b7c571fcf1c30785a4077f43b4ebe9646088a85ec929fb2242bd1f6f16ae236278aafa9827b10420a81d0466eb83d791c2b7"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05aa85ef-f4d2-491d-9740-846d319302ee/a741ae607242a3626fa2ad8ca00c91ac/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-musl-x64.tar.gz",
+            "hash": "05bc089d6587b7d4afda29c793b602b549fbf2eaa631ce7339167f5f5f572267e36414f01755eb34dfc89bfd4081ef1b61b56e322aefccfe1b1c805ad77d5a15"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/56b46d73-ccf0-47df-8a41-a90cd2333304/271d1b5ad2162b721b4b88a1fcad5bc1/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-x64.tar.gz",
+            "hash": "4ec2c9e8ed5e8ddaa52ed291c263412b754691ae2b95362ddc6fa75cfe087dbe59c7e4f65f21b0f096bc93967d04f4ea612a0c42c8a124ef4583d0de8daac01c"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94ec572d-4b5a-4077-a96d-0da66a95cece/eb406d9b0e4628f5e259452ca08145eb/aspnetcore-runtime-5.0.0-preview.1.20124.5-osx-x64.tar.gz",
+            "hash": "79b48ab04f28e173d561bfe0ffd8d1099ae98c6a3a927c68a774a98b123c660cdcd68ea654c3baf3c87e1109a6e48a9fe54d9bcbed17655673789e8bc5c35225"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f0fcc7bd-977d-4e47-ae93-6cef16bffa52/2bac08d7be3f536baef009d7e2f51c27/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x64.exe",
+            "hash": "9b1d72c312b773ca4d7ae5193f2d52123d784186e1bbbe62050887418425201cec440cc0cbf0e7cf398f5bfdb1266eef98270b232d8853cffd20f6bf15274eab"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/09dd37c6-1597-4e43-914c-2c97c257d527/c2551b6d795fe1d46e62121c1ee66ca0/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x64.zip",
+            "hash": "47ca5820673f38c4ba6760ea87495dc016d832028b4eba3dc087dce3be6c6bd9dd21293eb564870e349e72dd4572cfce442daaec9785ebfec8a3d1cde9b26744"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/97ca32bd-11f1-4c6c-9b02-bd7972d5fd49/31ec1ac0056d847f4f139cd6aa6ebd73/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x86.exe",
+            "hash": "50c6d8c4e6ab321c613056a7f84bef8f6f6877470b488a8ecac6466c2d99e200a66d07f78109828bf884fb1ab1c924181d8d0d1ad58e3f04bb58b3e7d025b814"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/08e464a2-d72d-4c54-8235-5bfd0cc08c59/63440fe56dc65097152443b0f94a9757/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x86.zip",
+            "hash": "2552ededd8e11ca1d16066351d91abe93ad85f23e9e79e8b855574df160964dabad537356c0e034ca03ad351799610b63a032e32ab0bc65d07ae7104b5c1ce2e"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/338371fd-ee7a-41aa-a012-6d612e92bcb3/4db8b8992a93c47355b2fc7bfed750e0/aspnetcore-runtime-5.0.0-preview.1.20124.5-x64.deb",
+            "hash": "8928f0056c579984e63ae13ee980441f34a8d050dbd4ccaa0968ddf56816b74e2ba001df2582746970eeab4d7850522015355642aa0d8b4901f46ccd50d76238"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d5e8781-9eb2-4a8e-8b52-42fa82d85d7a/df22d24384a341d956d709a11b29e509/aspnetcore-runtime-5.0.0-preview.1.20124.5-x64.rpm",
+            "hash": "c69518e3dceefc79db961359f5c284e271e22a0a9f348f5de5ee7a72dbbe6001d81d4558671d595d473421e9a6c10dee42a3ce72fa836b708b8864e08c44438f"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.deb",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3f186eb0-0d3e-49ee-863b-e7e0826b740f/3474a4667520b115f9069f2aadd74d22/aspnetcore-targeting-pack-5.0.0-preview.1.20124.5.deb",
+            "hash": "4c901f7162b9ffb4dd8ab40f3be346c1001f5cbcaff692a23d0bcdb30aa5fbf8803973ee37be6526291d9d54a2e2c76aaaeb7f3a893c03f80c9ef59835e1c6d1"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e7abdd13-9a7e-4a2a-90ac-aa2da134f5f4/1ed614b70ed7d1c5bc32f8a78fbf0672/aspnetcore-targeting-pack-5.0.0-preview.1.20124.5.rpm",
+            "hash": "f9dad74b74f0dc824554db41ff195d12f7a611be11b873fde9b8d80155ec5108c5d98a8473d7e963cf90ebfa2be5889ba704a716bad3ab29303b5c1f8abd6398"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0221e27a-7c9d-4123-aca0-ddde3c4d6001/cf53100f7de5187005cac9a5880e4879/dotnet-hosting-5.0.0-preview.1.20124.5-win.exe",
+            "hash": "e3bb2502552ed73ff48d7b2cd58c59029321c1b49fe93b43eb37ab7fa90f4cf8a91c01af67e3a46c7991db8d5c0cebab1e6cbeb95e49e0f6f49b5bf2846d7535"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.1.20127.5",
+        "version-display": "5.0.0-preview.1",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ad44996b-5d71-4b35-a009-08aed1ac1add/3cfc44f1463030caf61049a2d50e483a/windowsdesktop-runtime-5.0.0-preview.1.20127.5-win-x64.exe",
+            "hash": "15de7de22fa6c19c06053a8a88fdde52c6fb10fc7e0bb2703f30c42406a28feaa56de9b11fc295269eb4297c0239c9b558640e9963fa891d803a2072baa64387"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e6e08491-8da4-4a4d-9a92-e7323cc1174f/447dcd27c06a92f66209c70bdf453b65/windowsdesktop-runtime-5.0.0-preview.1.20127.5-win-x86.exe",
+            "hash": "dfb97c3c85b35ae00b95ad6a60bfdffb9244ec807012d55f0b5bd7696c3600acc006be653ee2045fcf1f368ff4cce26761e504d7cdcf85d94863aa48ce77f4e7"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.1.20120.5",
+        "files": []
+      }
+    }
+  ],
+  "intellisense": {
+    "version": "5.0.0",
+    "version-display": "5.0.0",
+    "files": [
+      {
+        "lang": "de",
+        "name": "dotnet-intellisense-de.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/1b564d34-d4a5-41d7-8c05-7cce04240209/1fe34c510fab8d0519ed864db08d29b6/dotnet-intellisense-5.0-de.zip",
+        "hash": "1667ca5aee0c23659ee0252079f147f7cdc805c9a6de2f5569c3edf3ea5f5eee5c51aaa11f6dfe9da1506e298f51bb90bac2ed489608a50bde652a7b22854146"
+      },
+      {
+        "lang": "es",
+        "name": "dotnet-intellisense-es.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/537b8862-8ab8-4436-a0ac-5f0ae5c5e057/4ff37ab9681636e50df259a3f854abbd/dotnet-intellisense-5.0-es.zip",
+        "hash": "89ca4e8c185a0ac7f1b4094de305af554342fd871ea6d50ff243ee1ac223368991954bff7800798ae5a184ec89cc9799fd31bc6fb275d1901317d3eaa1ab2706"
+      },
+      {
+        "lang": "fr",
+        "name": "dotnet-intellisense-fr.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/81313591-3cc0-4656-bea4-9b94635c1fad/f2d2ec3cc994db0ba6d79ce8bb04daf2/dotnet-intellisense-5.0-fr.zip",
+        "hash": "152ee5d4b7ccf24ecd47f25b3fc1e0adc69f2793e3bdccc2142ee7b91d0a4fe6bbee89de4abace6f9d8430a07f778008d0e5acc8eb626e3c70a09930691988fe"
+      },
+      {
+        "lang": "it",
+        "name": "dotnet-intellisense-it.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/d7b17452-50b0-47b4-b267-38fad379ac9f/735377318efc6e9872758a0cfe3b3de4/dotnet-intellisense-5.0-it.zip",
+        "hash": "49ad015460281b18b432e74184a70b287dff6a0c9e6394c58f7f52130bdfd8a7ba1e335484fc8d2b2917d4ff21b299342439756c721fd10e058f2a34c06bef3a"
+      },
+      {
+        "lang": "ja",
+        "name": "dotnet-intellisense-ja.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/ce8844a5-3756-4a30-bbc4-6145c7ca1641/65f2a0e2895b11bfab278bb56b10db19/dotnet-intellisense-5.0-ja.zip",
+        "hash": "5150fcd633c83cb9be5d76ad81159b885ed0bf8a225d2b0b54ed556c6ae68c8d715c3fd592c9e334a01acc7889fbfd3a1119c8caff5d2074483c75506c06f572"
+      },
+      {
+        "lang": "ko",
+        "name": "dotnet-intellisense-ko.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/be274342-9aa3-4a48-a25e-d18c775647dc/ba605d02aa521fc040ea92e7526c95f6/dotnet-intellisense-5.0-ko.zip",
+        "hash": "8f2ac1f126ab62aa20902353beed5cb8162a46f3a9e343f5bbfd7d31072f09f8c069a53ebca627c4ff7a44ecfa1a2a817ac74642d5b3a6b51dd35da73d3e9f3f"
+      },
+      {
+        "lang": "pt-br",
+        "name": "dotnet-intellisense-pt-br.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/82150755-fe54-4f16-8ac3-08863a36a435/199031d5ba13352c819820f5d4870055/dotnet-intellisense-5.0-pt-br.zip",
+        "hash": "f80266fcd1101713dccb4efab0c7113e701157c20b65036697f80c7292009a0d56b385e0df10c41334b5137f3f957598de220029311c01f1c687e924c58f74c6"
+      },
+      {
+        "lang": "ru",
+        "name": "dotnet-intellisense-ru.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/73168f84-ea81-443f-be83-84e56eaf4116/732d5441e0ece404c503803e16c38ae1/dotnet-intellisense-5.0-ru.zip",
+        "hash": "f61e620c735da379312b799c4de004c282a4693bcc8c7a0d8cd85f7718a7b59f2fcd534840b4e9fb7a4d627da49f0f0aeeeeec8cbab07db62cc1fe1dad675ef5"
+      },
+      {
+        "lang": "zh-hans",
+        "name": "dotnet-intellisense-zh-hans.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/42239244-de7e-4018-b6b4-f7e4c15ddc82/2856eacff59637019ff16b017504f8e8/dotnet-intellisense-5.0-zh-hans.zip",
+        "hash": "a9d2659aab2fd6b11207546c1c296dc1edb9df525aeb44578b7e3f78e6fa994b858340c135fac8c147f3ce2c43b3543ec2146d15d4452de1ec65bc89508f8889"
+      },
+      {
+        "lang": "zh-hant",
+        "name": "dotnet-intellisense-zh-hant.zip",
+        "rid": "",
+        "url": "https://download.visualstudio.microsoft.com/download/pr/c96c3958-a360-40b0-85a1-9f4a349afaca/781241cc39c988e6d27345eadab7aad2/dotnet-intellisense-5.0-zh-hant.zip",
+        "hash": "4d7b1b2d04828d4c5abc5228c7e1f630bdad8283f5d7a615203663316288fc40e978679ed5cec280c7e3daea72caa6cfd2f1f6f6421b0603225506b58e41afbf"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
  * Fix SDK updates not working for the same runtime but a newer MSBuild version (e.g. 5.0.103 to 5.0.200 which both had .NET 5.0.3).
  * Deduplicate CVEs between SDK releases for if there's just code changes and no new runtime release and the CVE list is the same.