### PR TITLE
Add update information to commit messages

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "npm test",
+      "request": "launch",
+      "runtimeArgs": [
+        "run-script",
+        "test"
+      ],
+      "runtimeExecutable": "npm",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node"
+    }
+  ]
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,7 +11,11 @@ module.exports =
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -98,7 +102,7 @@ class DotNetSdkUpdater {
     async createPullRequest(base, versions) {
         var _a;
         const title = `Update .NET SDK to ${versions.latest.sdkVersion}`;
-        let body = `Updates the .NET SDK to version [\`\`${versions.latest.sdkVersion}\`\`](https://github.com/dotnet/core/blob/master/release-notes/${this.options.channel}/${versions.latest.runtimeVersion}/${versions.latest.sdkVersion}-download.md), `;
+        let body = `Updates the .NET SDK to version [\`\`${versions.latest.sdkVersion}\`\`](https://github.com/dotnet/core/blob/main/release-notes/${this.options.channel}/${versions.latest.runtimeVersion}/${versions.latest.sdkVersion}-download.md), `;
         if (versions.latest.runtimeVersion === versions.current.runtimeVersion) {
             body += `which includes version [\`\`${versions.latest.runtimeVersion}\`\`](${versions.latest.releaseNotes}) of the .NET runtime.`;
         }
@@ -196,7 +200,7 @@ class DotNetSdkUpdater {
             allowRetries: true,
             maxRetries: 3
         });
-        const releasesUrl = `https://raw.githubusercontent.com/dotnet/core/master/release-notes/${this.options.channel}/releases.json`;
+        const releasesUrl = `https://raw.githubusercontent.com/dotnet/core/main/release-notes/${this.options.channel}/releases.json`;
         core.debug(`Downloading .NET ${this.options.channel} release notes JSON from ${releasesUrl}...`);
         const releasesResponse = await httpClient.getJson(releasesUrl);
         if (releasesResponse.statusCode >= 400) {
@@ -266,7 +270,25 @@ class DotNetSdkUpdater {
             this.options.branch = `update-dotnet-sdk-${releaseInfo.latest.sdkVersion}`.toLowerCase();
         }
         if (!this.options.commitMessage) {
-            this.options.commitMessage = `Update .NET SDK\n\nUpdate .NET SDK to version ${releaseInfo.latest.sdkVersion}.`;
+            const currentVersion = releaseInfo.current.sdkVersion.split('.');
+            const latestVersion = releaseInfo.latest.sdkVersion.split('.');
+            const updateKind = latestVersion[0] > currentVersion[0] ? 'major' :
+                latestVersion[1] > currentVersion[1] ? 'minor' :
+                    'patch';
+            const messageLines = [
+                'Update .NET SDK',
+                '',
+                `Update .NET SDK to version ${releaseInfo.latest.sdkVersion}.`,
+                '',
+                '---',
+                'updated-dependencies:',
+                '- dependency-name: Microsoft.NET.Sdk',
+                `  update-type: version-update:semver-${updateKind}`,
+                '...',
+                '',
+                ''
+            ];
+            this.options.commitMessage = messageLines.join('\n');
         }
         if (this.options.userName) {
             await this.execGit(["config", "user.name", this.options.userName]);
@@ -297,7 +319,7 @@ class DotNetSdkUpdater {
         await this.execGit(["commit", "-m", this.options.commitMessage]);
         const sha1 = await this.execGit(["log", "--format='%H'", "-n", "1"]);
         const shortSha1 = sha1.replace("'", "").substring(0, 7);
-        core.info(`Commited .NET SDK update to git (${shortSha1})`);
+        core.info(`Committed .NET SDK update to git (${shortSha1})`);
         if (!this.options.dryRun && this.options.repo) {
             await this.execGit(["push", "-u", "origin", this.options.branch], true);
             core.info(`Pushed changes to repository (${this.options.repo})`);
@@ -327,7 +349,11 @@ class NullWritable extends stream_1.Writable {
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/dist/index.js
+++ b/dist/index.js
@@ -272,8 +272,8 @@ class DotNetSdkUpdater {
         if (!this.options.commitMessage) {
             const currentVersion = releaseInfo.current.sdkVersion.split('.');
             const latestVersion = releaseInfo.latest.sdkVersion.split('.');
-            const updateKind = latestVersion[0] > currentVersion[0] ? 'major' :
-                latestVersion[1] > currentVersion[1] ? 'minor' :
+            const updateKind = parseInt(latestVersion[0], 10) > parseInt(currentVersion[0], 10) ? 'major' :
+                parseInt(latestVersion[1], 10) > parseInt(currentVersion[1], 10) ? 'minor' :
                     'patch';
             const messageLines = [
                 'Update .NET SDK',

--- a/src/DotNetSdkUpdater.ts
+++ b/src/DotNetSdkUpdater.ts
@@ -104,7 +104,7 @@ export class DotNetSdkUpdater {
 
     const title = `Update .NET SDK to ${versions.latest.sdkVersion}`;
 
-    let body = `Updates the .NET SDK to version [\`\`${versions.latest.sdkVersion}\`\`](https://github.com/dotnet/core/blob/master/release-notes/${this.options.channel}/${versions.latest.runtimeVersion}/${versions.latest.sdkVersion}-download.md), `;
+    let body = `Updates the .NET SDK to version [\`\`${versions.latest.sdkVersion}\`\`](https://github.com/dotnet/core/blob/main/release-notes/${this.options.channel}/${versions.latest.runtimeVersion}/${versions.latest.sdkVersion}-download.md), `;
 
     if (versions.latest.runtimeVersion === versions.current.runtimeVersion) {
       body += `which includes version [\`\`${versions.latest.runtimeVersion}\`\`](${versions.latest.releaseNotes}) of the .NET runtime.`;
@@ -229,7 +229,7 @@ export class DotNetSdkUpdater {
       maxRetries: 3
     });
 
-    const releasesUrl = `https://raw.githubusercontent.com/dotnet/core/master/release-notes/${this.options.channel}/releases.json`;
+    const releasesUrl = `https://raw.githubusercontent.com/dotnet/core/main/release-notes/${this.options.channel}/releases.json`;
 
     core.debug(`Downloading .NET ${this.options.channel} release notes JSON from ${releasesUrl}...`);
 

--- a/src/DotNetSdkUpdater.ts
+++ b/src/DotNetSdkUpdater.ts
@@ -328,7 +328,29 @@ export class DotNetSdkUpdater {
     }
 
     if (!this.options.commitMessage) {
-      this.options.commitMessage = `Update .NET SDK\n\nUpdate .NET SDK to version ${releaseInfo.latest.sdkVersion}.`;
+
+      const currentVersion = releaseInfo.current.sdkVersion.split('.');
+      const latestVersion = releaseInfo.latest.sdkVersion.split('.');
+
+      const updateKind =
+        latestVersion[0] > currentVersion[0] ? 'major' :
+        latestVersion[1] > currentVersion[1] ? 'minor' :
+        'patch';
+
+      const messageLines = [
+        'Update .NET SDK',
+        '',
+        `Update .NET SDK to version ${releaseInfo.latest.sdkVersion}.`,
+        '',
+        '---',
+        'updated-dependencies:',
+        '- dependency-name: Microsoft.NET.Sdk',
+        `  update-type: version-update:semver-${updateKind}`,
+        '...',
+        '',
+        ''
+      ];
+      this.options.commitMessage = messageLines.join('\n');
     }
 
     if (this.options.userName) {

--- a/src/DotNetSdkUpdater.ts
+++ b/src/DotNetSdkUpdater.ts
@@ -370,7 +370,7 @@ export class DotNetSdkUpdater {
     const sha1 = await this.execGit([ "log", "--format='%H'", "-n", "1" ]);
     const shortSha1 = sha1.replace("'", "").substring(0, 7);
 
-    core.info(`Commited .NET SDK update to git (${shortSha1})`);
+    core.info(`Committed .NET SDK update to git (${shortSha1})`);
 
     if (!this.options.dryRun && this.options.repo) {
       await this.execGit([ "push", "-u", "origin", this.options.branch ], true);

--- a/src/DotNetSdkUpdater.ts
+++ b/src/DotNetSdkUpdater.ts
@@ -333,8 +333,8 @@ export class DotNetSdkUpdater {
       const latestVersion = releaseInfo.latest.sdkVersion.split('.');
 
       const updateKind =
-        latestVersion[0] > currentVersion[0] ? 'major' :
-        latestVersion[1] > currentVersion[1] ? 'minor' :
+        parseInt(latestVersion[0], 10) > parseInt(currentVersion[0], 10) ? 'major' :
+        parseInt(latestVersion[1], 10) > parseInt(currentVersion[1], 10) ? 'minor' :
         'patch';
 
       const messageLines = [

--- a/tests/DotNetSdkUpdater.test.ts
+++ b/tests/DotNetSdkUpdater.test.ts
@@ -21,13 +21,13 @@ describe("DotNetSdkUpdater tests", () => {
     expect(actual.current).not.toBeNull();
     expect(actual.latest).not.toBeNull();
 
-    expect(actual.current.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.0/3.1.0.md");
+    expect(actual.current.releaseNotes).toBe("https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.0/3.1.0.md");
     expect(actual.current.runtimeVersion).toBe("3.1.0");
     expect(actual.current.sdkVersion).toBe("3.1.100");
     expect(actual.current.security).toBe(false);
     expect(actual.current.securityIssues).not.toBeNull();
 
-    expect(actual.latest.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.10/3.1.10.md");
+    expect(actual.latest.releaseNotes).toBe("https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.10/3.1.10.md");
     expect(actual.latest.runtimeVersion).toBe("3.1.10");
     expect(actual.latest.sdkVersion).toBe("3.1.404");
     expect(actual.latest.security).toBe(false);
@@ -47,7 +47,7 @@ describe("DotNetSdkUpdater tests", () => {
     expect(actual.current).not.toBeNull();
     expect(actual.latest).not.toBeNull();
 
-    expect(actual.current.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.3/5.0.200-sdk.md");
+    expect(actual.current.releaseNotes).toBe("https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.3/5.0.200-sdk.md");
     expect(actual.current.runtimeVersion).toBe("5.0.3");
     expect(actual.current.sdkVersion).toBe("5.0.103");
     expect(actual.current.security).toBe(true);
@@ -56,7 +56,7 @@ describe("DotNetSdkUpdater tests", () => {
     expect(actual.current.securityIssues[0].id).toBe("CVE-2021-1721");
     expect(actual.current.securityIssues[1].id).toBe("CVE-2021-24112");
 
-    expect(actual.latest.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.3/5.0.200-sdk.md");
+    expect(actual.latest.releaseNotes).toBe("https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.3/5.0.200-sdk.md");
     expect(actual.latest.runtimeVersion).toBe("5.0.3");
     expect(actual.latest.sdkVersion).toBe("5.0.200");
     expect(actual.latest.security).toBe(true);
@@ -79,12 +79,12 @@ describe("DotNetSdkUpdater tests", () => {
     expect(actual.current).not.toBeNull();
     expect(actual.latest).not.toBeNull();
 
-    expect(actual.current.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.10/3.1.10.md");
+    expect(actual.current.releaseNotes).toBe("https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.10/3.1.10.md");
     expect(actual.current.runtimeVersion).toBe("3.1.10");
     expect(actual.current.sdkVersion).toBe("3.1.404");
     expect(actual.current.security).toBe(false);
 
-    expect(actual.latest.releaseNotes).toBe("https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.10/3.1.10.md");
+    expect(actual.latest.releaseNotes).toBe("https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.10/3.1.10.md");
     expect(actual.latest.runtimeVersion).toBe("3.1.10");
     expect(actual.latest.sdkVersion).toBe("3.1.404");
     expect(actual.latest.security).toBe(false);

--- a/tests/releases-3.1.json
+++ b/tests/releases-3.1.json
@@ -8,11 +8,11 @@
   "eol-date": "2022-12-03",
   "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
   "releases": [
-    {    
+    {
       "release-date": "2020-11-10",
       "release-version": "3.1.10",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.10/3.1.10.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.10/3.1.10.md",
       "runtime": {
         "version": "3.1.10",
         "version-display": "3.1.10",
@@ -465,7 +465,7 @@
       "release-date": "2020-10-13",
       "release-version": "3.1.9",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.9/3.1.9.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.9/3.1.9.md",
       "runtime": {
         "version": "3.1.9",
         "version-display": "3.1.9",
@@ -924,7 +924,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1045"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.8/3.1.8.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.8/3.1.8.md",
       "runtime": {
         "version": "3.1.8",
         "version-display": "3.1.8",
@@ -1380,7 +1380,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1597"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.7/3.1.7.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.7/3.1.7.md",
       "runtime": {
         "version": "3.1.7",
         "version-display": "3.1.7",
@@ -1836,7 +1836,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1147"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.6/3.1.6.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.6/3.1.6.md",
       "runtime": {
         "version": "3.1.6",
         "version-display": "3.1.6",
@@ -2292,7 +2292,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1108"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.5/3.1.5.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.5/3.1.5.md",
       "runtime": {
         "version": "3.1.5",
         "version-display": "3.1.5",
@@ -2734,7 +2734,7 @@
         "files": []
       }
     },
-    {      
+    {
       "release-date": "2020-05-19",
       "release-version": "3.1.4",
       "security": true,
@@ -2748,7 +2748,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1161"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.4/3.1.4.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.4/3.1.4.md",
       "runtime": {
         "version": "3.1.4",
         "version-display": "3.1.4",
@@ -3277,7 +3277,7 @@
       "release-date": "2020-03-24",
       "release-version": "3.1.3",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.3/3.1.3.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.3/3.1.3.md",
       "runtime": {
         "version": "3.1.3",
         "version-display": "3.1.3",
@@ -3723,7 +3723,7 @@
       "release-date": "2020-03-16",
       "release-version": "3.1.2",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.2/3.1.2.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.2/3.1.2.md",
       "runtime": {
         "version": "3.1.2",
         "version-display": "3.1.2",
@@ -4186,7 +4186,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-0606"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.1/3.1.1.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.1/3.1.1.md",
       "runtime": {
         "version": "3.1.1",
         "version-display": "3.1.1",
@@ -4550,7 +4550,7 @@
       "release-version": "3.1.0",
       "security": false,
       "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.0/3.1.0.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.0/3.1.0.md",
       "runtime": {
         "version": "3.1.0",
         "version-display": "3.1.0",
@@ -4940,7 +4940,7 @@
       "release-version": "3.1.0-preview3",
       "security": false,
       "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/preview/3.1.0-preview3.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/preview/3.1.0-preview3.md",
       "runtime": {
         "version": "3.1.0-preview3.19553.2",
         "version-display": "3.1.0-preview3",
@@ -5474,7 +5474,7 @@
       "release-version": "3.1.0-preview2",
       "security": false,
       "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/preview/3.1.0-preview2.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/preview/3.1.0-preview2.md",
       "runtime": {
         "version": "3.1.0-preview2.19525.6",
         "version-display": "3.1.0-preview2",
@@ -6021,7 +6021,7 @@
       "release-version": "3.1.0-preview1",
       "security": false,
       "cve-list": [],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/3.1/preview/3.1.0-preview1.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/3.1/preview/3.1.0-preview1.md",
       "runtime": {
         "version": "3.1.0-preview1.19506.1",
         "version-display": "3.1.0-preview1",

--- a/tests/releases-5.0.json
+++ b/tests/releases-5.0.json
@@ -21,7 +21,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24112"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.3/5.0.200-sdk.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.3/5.0.200-sdk.md",
       "runtime": {
         "version": "5.0.3",
         "version-display": "5.0.3",
@@ -480,7 +480,7 @@
           "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-1723"
         }
       ],
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.2/5.0.2.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.2/5.0.2.md",
       "runtime": {
         "version": "5.0.2",
         "version-display": "5.0.2",
@@ -847,7 +847,7 @@
       "release-date": "2020-12-08",
       "release-version": "5.0.1",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.1/5.0.1.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.1/5.0.1.md",
       "runtime": {
         "version": "5.0.1",
         "version-display": "5.0.1",
@@ -1214,7 +1214,7 @@
       "release-date": "2020-11-10",
       "release-version": "5.0.0",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0.0/5.0.0.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.0/5.0.0.md",
       "runtime": {
         "version": "5.0.0",
         "version-display": "5.0.0",
@@ -1581,7 +1581,7 @@
       "release-date": "2020-10-13",
       "release-version": "5.0.0-rc.2",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-rc.2.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-rc.2.md",
       "runtime": {
         "version": "5.0.0-rc.2.20475.5",
         "version-display": "5.0.0-rc.2",
@@ -1954,7 +1954,7 @@
       "release-date": "2020-09-14",
       "release-version": "5.0.0-rc.1",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-rc.1.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-rc.1.md",
       "runtime": {
         "version": "5.0.0-rc.1.20451.14",
         "version-display": "5.0.0-rc.1",
@@ -2315,7 +2315,7 @@
       "release-date": "2020-08-25",
       "release-version": "5.0.0-preview.8",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.8.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.8.md",
       "runtime": {
         "version": "5.0.0-preview.8.20407.11",
         "version-display": "5.0.0-preview.8",
@@ -2670,7 +2670,7 @@
       "release-date": "2020-07-21",
       "release-version": "5.0.0-preview.7",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.7.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.7.md",
       "runtime": {
         "version": "5.0.0-preview.7.20364.11",
         "version-display": "5.0.0-preview.7",
@@ -3019,7 +3019,7 @@
       "release-date": "2020-06-25",
       "release-version": "5.0.0-preview.6",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.6.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.6.md",
       "runtime": {
         "version": "5.0.0-preview.6.20305.6",
         "version-display": "5.0.0-preview.6",
@@ -3364,7 +3364,7 @@
       "release-date": "2020-06-10",
       "release-version": "5.0.0-preview.5",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.5.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.5.md",
       "runtime": {
         "version": "5.0.0-preview.5.20278.1",
         "version-display": "5.0.0-preview.5",
@@ -3709,7 +3709,7 @@
       "release-date": "2020-05-19",
       "release-version": "5.0.0-preview.4",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.4.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.4.md",
       "runtime": {
         "version": "5.0.0-preview.4.20251.6",
         "version-display": "5.0.0-preview.4",
@@ -4056,7 +4056,7 @@
       "release-date": "2020-04-23",
       "release-version": "5.0.0-preview.3",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.3.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.3.md",
       "runtime": {
         "version": "5.0.0-preview.3.20214.6",
         "version-display": "5.0.0-preview.3",
@@ -4385,7 +4385,7 @@
       "release-date": "2020-04-02",
       "release-version": "5.0.0-preview.2",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.2.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.2.md",
       "runtime": {
         "version": "5.0.0-preview.2.20160.6",
         "version-display": "5.0.0-preview.2",
@@ -4876,7 +4876,7 @@
       "release-date": "2020-03-16",
       "release-version": "5.0.0-preview.1",
       "security": false,
-      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.1.md",
+      "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/5.0/preview/5.0.0-preview.1.md",
       "runtime": {
         "version": "5.0.0-preview.1.20120.5",
         "version-display": "5.0.0-preview.1",


### PR DESCRIPTION
Add information, based on the format dependabot uses, to the commit messages that show the version update that was performed.

This is to support parsing the commit messages with automated tooling.

For example:

```
Update .NET SDK

Update .NET SDK to version 3.1.417.

---
updated-dependencies:
- dependency-name: Microsoft.NET.Sdk
  update-type: version-update:semver-patch
...

```

Also:

- Fixes typo in log message.
- Updates the default branch name in the release note URLs.
- Adds Visual Studio Code configuration files for debugging.
