### PR TITLE
Remove SDK release notes URL

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -124,7 +124,7 @@ class DotNetSdkUpdater {
     async createPullRequest(base, versions) {
         var _a;
         const title = `Update .NET SDK to ${versions.latest.sdkVersion}`;
-        let body = `Updates the .NET SDK to version [\`\`${versions.latest.sdkVersion}\`\`](https://github.com/dotnet/core/blob/main/release-notes/${this.options.channel}/${versions.latest.runtimeVersion}/${versions.latest.sdkVersion}-download.md), `;
+        let body = `Updates the .NET SDK to version \`${versions.latest.sdkVersion}\`, `;
         if (versions.latest.runtimeVersion === versions.current.runtimeVersion) {
             body += `which includes version [\`\`${versions.latest.runtimeVersion}\`\`](${versions.latest.releaseNotes}) of the .NET runtime.`;
         }

--- a/src/DotNetSdkUpdater.ts
+++ b/src/DotNetSdkUpdater.ts
@@ -130,7 +130,7 @@ export class DotNetSdkUpdater {
 
     const title = `Update .NET SDK to ${versions.latest.sdkVersion}`;
 
-    let body = `Updates the .NET SDK to version [\`\`${versions.latest.sdkVersion}\`\`](https://github.com/dotnet/core/blob/main/release-notes/${this.options.channel}/${versions.latest.runtimeVersion}/${versions.latest.sdkVersion}-download.md), `;
+    let body = `Updates the .NET SDK to version \`${versions.latest.sdkVersion}\`, `;
 
     if (versions.latest.runtimeVersion === versions.current.runtimeVersion) {
       body += `which includes version [\`\`${versions.latest.runtimeVersion}\`\`](${versions.latest.releaseNotes}) of the .NET runtime.`;


### PR DESCRIPTION
Remove the URL for the .NET SDK release notes as it generally doesn't exist and just causes an HTTP 404.
