### PR TITLE
Add top-level permission

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -66,6 +66,9 @@ on:
 env:
   TERM: xterm
 
+permissions:
+  contents: read
+
 jobs:
 
   update-dotnet-sdk:


### PR DESCRIPTION
Add an explicit top-level permission, assuming it won't interfere with the token passed to the workflow which may have more permissions.
