### PR TITLE
Remove permissions

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -66,9 +66,6 @@ on:
 env:
   TERM: xterm
 
-permissions:
-  contents: read
-
 jobs:
 
   update-dotnet-sdk:


### PR DESCRIPTION
Remove `permissions` as it downgrades the calling workflow's permissions and [breaks the workflow](https://github.com/martincostello/update-dotnet-sdk/actions/runs/4744386843/jobs/8425225126#step:3:25).
