### PR TITLE
Consume self for the workflow

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -110,7 +110,7 @@ jobs:
     # for the same release channel as the SDK specified in global.json.
     - name: Update .NET SDK
       id: update-dotnet-sdk
-      uses: martincostello/update-dotnet-sdk@8d99db1db36692f0d5c5bf3ef91fb654c2d4e298 # v2.1.0
+      uses: ./
       with:
         branch-name: ${{ inputs.branch-name }}
         channel: ${{ inputs.channel }}


### PR DESCRIPTION
Consume the workflow from the current commit so that when the repo is tagged it doesn't use the action from the previous release.
