### PR TITLE
Pin action in workflow

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -110,7 +110,7 @@ jobs:
     # for the same release channel as the SDK specified in global.json.
     - name: Update .NET SDK
       id: update-dotnet-sdk
-      uses: martincostello/update-dotnet-sdk@8d99db1db36692f0d5c5bf3ef91fb654c2d4e298 # v2.1.0
+      uses: martincostello/update-dotnet-sdk@b15fdfa618412cbab29d85ecac160d073cd58186
       with:
         branch-name: ${{ inputs.branch-name }}
         channel: ${{ inputs.channel }}


### PR DESCRIPTION
Pin the reusable workflow to the SHA of the action immediately before this commit so it's as consistent as possible before tagging v2.1.1.
