### PR TITLE
Add support for GitHub Apps

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -199,10 +199,10 @@ jobs:
         # The --include flags are used to only update Microsoft-published
         # NuGet packages that are typically published with a new patch
         # release of .NET that accompanies a new .NET SDK release.
-        $eligblePackages = "${{ inputs.include-nuget-packages }}".Split(',')
+        $eligiblePackages = "${{ inputs.include-nuget-packages }}".Split(',')
         $includePackages = @()
 
-        foreach ($package in $eligblePackages) {
+        foreach ($package in $eligiblePackages) {
           $includePackages += "--include"
           $includePackages += $package
         }

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -134,7 +134,7 @@ jobs:
       with:
         application_id: ${{ secrets.application-id }}
         application_private_key: ${{ secrets.application-private-key }}
-        permissions: "contents:write, pull_requests:write, workflows:write"
+        permissions: "contents:write, pull_requests:write"
 
     - name: Use GitHub application token
       if: ${{ steps.validate-secrets.outputs.use-github-app == 'true' }}

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -120,12 +120,6 @@ jobs:
             }
           }
 
-    # If a GitHub access token was provided, use that
-    - name: Use GitHub access token
-      if: ${{ steps.validate-secrets.outputs.use-github-app != 'true' }}
-      shell: pwsh
-      run: Write-Host "ACCESS_TOKEN=${{ secrets.repo-token }}" >> $env:GITHUB_ENV
-
     # If credentials for a GitHub application were provided, use them to generate a GitHub access token
     - name: Generate GitHub application token
       id: generate-application-token
@@ -136,10 +130,15 @@ jobs:
         application_private_key: ${{ secrets.application-private-key }}
         permissions: "contents:write, pull_requests:write"
 
-    - name: Use GitHub application token
-      if: ${{ steps.validate-secrets.outputs.use-github-app == 'true' }}
+    - name: Assign GitHub token
+      id: assign-token
       shell: pwsh
-      run: Write-Host "ACCESS_TOKEN=${{ steps.generate-application-token.outputs.token }}" >> $env:GITHUB_ENV
+      run: |
+        if (![string]::IsNullOrEmpty("${{ secrets.repo-token }}")) {
+            Write-Host "access-token=${{ secrets.repo-token }}" >> $env:GITHUB_OUTPUT
+        } else {
+            Write-Host "access-token=${{ steps.generate-application-token.outputs.token }}" >> $env:GITHUB_OUTPUT
+        }
 
     # Checkout the repository so the global.json file can be inspected and
     # updated if a new patch version of the SDK is available. The token is
@@ -149,7 +148,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
-        token: ${{ env.ACCESS_TOKEN }}
+        token: ${{ steps.assign-token.outcome.outputs.access-token }}
 
     # Run the action to check if a new version of the .NET SDK is available
     # for the same release channel as the SDK specified in global.json.
@@ -163,7 +162,7 @@ jobs:
         dry-run: ${{ inputs.dry-run }}
         global-json-file: ${{ inputs.global-json-file }}
         labels: ${{ inputs.labels }}
-        repo-token: ${{ env.ACCESS_TOKEN }}
+        repo-token: ${{ steps.assign-token.outcome.outputs.access-token }}
         user-email: ${{ inputs.user-email }}
         user-name: ${{ inputs.user-name }}
 

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -108,12 +108,12 @@ jobs:
       uses: actions/github-script@v3
       with:
         script: |
-          if ('${{ secrets.repo-token }}'.length !== 0) {
+          if (`${{ secrets.repo-token }}`.length !== 0) {
             core.setOutput('use-github-app', 'false');
           }
           else {
-            if ('${{ secrets.application-id }}'.length === 0 ||
-                '${{ secrets.application-private-key }}'.length === 0) {
+            if (`${{ secrets.application-id }}`.length === 0 ||
+                `${{ secrets.application-private-key }}`.length === 0) {
               core.setFailed('Either the repo-token or application-id and application-private-key secrets must be set.');
             } else {
               core.setOutput('use-github-app', 'true');

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -74,7 +74,13 @@ on:
     secrets:
       repo-token:
         description: 'The GitHub access token to use to clone the repository, push changes and create a Pull Request for any SDK update.'
-        required: true
+        required: false
+      application-id:
+        description: 'The ID of a GitHub Application to generate a GitHub Access token for to use to clone the repository, push changes and create a Pull Request for any SDK update.'
+        required: false
+      application-private-key:
+        description: 'The private key of a GitHub Application to generate a GitHub Access token for to use to clone the repository, push changes and create a Pull Request for any SDK update.'
+        required: false
 
 env:
   TERM: xterm
@@ -96,6 +102,45 @@ jobs:
 
     steps:
 
+    # Ensure that one of the required type of secrets has been specified
+    - name: Validate secrets
+      id: validate-secrets
+      uses: actions/github-script@v3
+      with:
+        script: |
+          if ('${{ secrets.repo-token }}'.length !== 0) {
+            core.setOutput('use-github-app', 'false');
+          }
+          else {
+            if ('${{ secrets.application-id }}'.length === 0 ||
+                '${{ secrets.application-private-key }}'.length === 0)) {
+              core.setFailed('Either the repo-token or application-id and application-private-key secrets must be set.');
+            } else {
+              core.setOutput('use-github-app', 'true');
+            }
+          }
+
+    # If a GitHub personal access token was provided, use that
+    - name: Use GitHub token
+      if: ${{ steps.validate-secrets.outputs.use-github-app != 'true' }}
+      shell: pwsh
+      run: Write-Host "ACCESS_TOKEN=${{ secrets.repo-token }}" >> $env:GITHUB_ENV
+
+    # If credentials for a GitHub application were provided, use them to generate a GitHub access token
+    - name: Generate GitHub application token
+      id: generate-application-token
+      if: ${{ steps.validate-secrets.outputs.use-github-app == 'true' }}
+      uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+      with:
+        application_id: ${{ secrets.application-id }}
+        application_private_key: ${{ secrets.application-private-key }}
+        permissions: "contents:write, pull_requests:write, workflows:write"
+
+    - name: Use GitHub application token
+      if: ${{ steps.validate-secrets.outputs.use-github-app == 'true' }}
+      shell: pwsh
+      run: Write-Host "ACCESS_TOKEN=${{ steps.generate-application-token.outputs.token }}" >> $env:GITHUB_ENV
+
     # Checkout the repository so the global.json file can be inspected and
     # updated if a new patch version of the SDK is available. The token is
     # used so that the workflow can push any changes back to the repository
@@ -104,7 +149,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
-        token: ${{ secrets.repo-token }}
+        token: ${{ env.ACCESS_TOKEN }}
 
     # Run the action to check if a new version of the .NET SDK is available
     # for the same release channel as the SDK specified in global.json.
@@ -118,7 +163,7 @@ jobs:
         dry-run: ${{ inputs.dry-run }}
         global-json-file: ${{ inputs.global-json-file }}
         labels: ${{ inputs.labels }}
-        repo-token: ${{ secrets.repo-token }}
+        repo-token: ${{ env.ACCESS_TOKEN }}
         user-email: ${{ inputs.user-email }}
         user-name: ${{ inputs.user-name }}
 

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -148,7 +148,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
-        token: ${{ steps.assign-token.outcome.outputs.access-token }}
+        token: ${{ steps.assign-token.outputs.access-token }}
 
     # Run the action to check if a new version of the .NET SDK is available
     # for the same release channel as the SDK specified in global.json.
@@ -162,7 +162,7 @@ jobs:
         dry-run: ${{ inputs.dry-run }}
         global-json-file: ${{ inputs.global-json-file }}
         labels: ${{ inputs.labels }}
-        repo-token: ${{ steps.assign-token.outcome.outputs.access-token }}
+        repo-token: ${{ steps.assign-token.outputs.access-token }}
         user-email: ${{ inputs.user-email }}
         user-name: ${{ inputs.user-name }}
 

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -135,9 +135,9 @@ jobs:
       shell: pwsh
       run: |
         if (![string]::IsNullOrEmpty("${{ secrets.repo-token }}")) {
-            Write-Host "access-token=${{ secrets.repo-token }}" >> $env:GITHUB_OUTPUT
+            "access-token=${{ secrets.repo-token }}" >> $env:GITHUB_OUTPUT
         } else {
-            Write-Host "access-token=${{ steps.generate-application-token.outputs.token }}" >> $env:GITHUB_OUTPUT
+            "access-token=${{ steps.generate-application-token.outputs.token }}" >> $env:GITHUB_OUTPUT
         }
 
     # Checkout the repository so the global.json file can be inspected and

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -113,15 +113,15 @@ jobs:
           }
           else {
             if ('${{ secrets.application-id }}'.length === 0 ||
-                '${{ secrets.application-private-key }}'.length === 0)) {
+                '${{ secrets.application-private-key }}'.length === 0) {
               core.setFailed('Either the repo-token or application-id and application-private-key secrets must be set.');
             } else {
               core.setOutput('use-github-app', 'true');
             }
           }
 
-    # If a GitHub personal access token was provided, use that
-    - name: Use GitHub token
+    # If a GitHub access token was provided, use that
+    - name: Use GitHub access token
       if: ${{ steps.validate-secrets.outputs.use-github-app != 'true' }}
       shell: pwsh
       run: Write-Host "ACCESS_TOKEN=${{ secrets.repo-token }}" >> $env:GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -20,19 +20,21 @@ steps:
 
 ### Example Workflow
 
-Below is an example of a full GitHub Actions workflow to automate .NET SDK updates.
+Below is a minimal example of a full GitHub Actions workflow to automate .NET SDK updates.
 
 ```yml
 name: update-dotnet-sdk
 
 on:
 
-  # Run at 2100 UTC on Tuesday every week to pick up any updates from
-  # Patch Tuesday which occur on the second Tuesday of the month (PST).
+  # Scheduled trigger to check for .NET SDK updates at 2000 UTC every
+  # Tuesday so that a run will coincide with monthly Update Tuesday releases,
+  # which occur on the second Tuesday of the month (Pacific Standard Time),
+  # for security and non-security improvements to the .NET SDK and runtime.
   schedule:
-    - cron:  '00 21 * * TUE'
+    - cron:  '00 20 * * TUE'
 
-  # Support running the workflow manually on-demand.
+  # Manual trigger to update the .NET SDK on-demand.
   workflow_dispatch:
 
 jobs:
@@ -73,14 +75,8 @@ See the [GitHub documentation][personal-access-token] for more information on cr
 name: update-dotnet-sdk
 
 on:
-
-  # Scheduled trigger to check for .NET SDK updates at 2000 UTC every
-  # Tuesday so that a run will coincide with monthly Update Tuesday releases
-  # for security and non-security improvements to the .NET SDK and runtime.
   schedule:
     - cron:  '00 20 * * TUE'
-
-  # Manual trigger to update the .NET SDK on-demand.
   workflow_dispatch:
 
 # No additional permissions are required for GITHUB_TOKEN as we are using a PAT.
@@ -112,14 +108,8 @@ See the [GitHub documentation][create-github-app] for more information on creati
 name: update-dotnet-sdk
 
 on:
-
-  # Scheduled trigger to check for .NET SDK updates at 2000 UTC every
-  # Tuesday so that a run will coincide with monthly Update Tuesday releases
-  # for security and non-security improvements to the .NET SDK and runtime.
   schedule:
     - cron:  '00 20 * * TUE'
-
-  # Manual trigger to update the .NET SDK on-demand.
   workflow_dispatch:
 
 # No additional permissions are required for GITHUB_TOKEN as we are using an app.
@@ -164,14 +154,8 @@ See the [GitHub documentation][github-token] for more information on `GITHUB_TOK
 name: update-dotnet-sdk
 
 on:
-
-  # Scheduled trigger to check for .NET SDK updates at 2000 UTC every
-  # Tuesday so that a run will coincide with monthly Update Tuesday releases
-  # for security and non-security improvements to the .NET SDK and runtime.
   schedule:
     - cron:  '00 20 * * TUE'
-
-  # Manual trigger to update the .NET SDK on-demand.
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -46,14 +46,26 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Advanced Example Workflow
+### Advanced Workflow
 
-Below is an example of a full GitHub Actions workflow to automate .NET SDK updates that will
+Below is an example of an advanced GitHub Actions workflow to automate .NET SDK updates that will
 also use the [dotnet-outdated][dotnet-outdated] .NET Global Tool to update any NuGet packages
 for the current .NET SDK release channel that are available from NuGet.org if the .NET SDK is updated.
 
-This action leverages a [GitHub reusable workflow][reusable-workflow-docs] that is included
+This workflow leverages a [GitHub reusable workflow][reusable-workflow-docs] that is included
 in this repository, which can be found [here][reusable-workflow].
+
+The workflow supports being used with a GitHub [personal access token][personal-access-token],
+a [GitHub app][github-apps], or [`GITHUB_TOKEN`][github-token] (not recommended due to restrictions
+when [triggering a workflow from another workflow][triggering-workflows-from-a-workflow]).
+
+#### With a Personal Access Token
+
+This workflow uses a personal access token (PAT) to authenticate with GitHub on behalf of the
+user associated with the PAT. The PAT must have at least the `public_repo` scope (or `repo` for
+private repositories) to be able to push changes to the repository and open a pull request.
+
+See the [GitHub documentation][personal-access-token] for more information on creating a PAT.
 
 ```yaml
 name: update-dotnet-sdk
@@ -69,35 +81,111 @@ on:
   # Manual trigger to update the .NET SDK on-demand.
   workflow_dispatch:
 
-# Set the minumum permissions for GITHUB_TOKEN.
-# Use the commented-out additional permission if using GITHUB_TOKEN.
+# No additional permissions are required for GITHUB_TOKEN as we are using a PAT.
 permissions:
   contents: read
-  #pull-requests: read
 
+# The Git commit user name and email are set as variables in the organization or repository settings.
+# See https://docs.github.com/en/actions/learn-github-actions/variables.
 jobs:
-
   update-sdk:
-
     uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@v2
-
-    # Set minimum required write permissions if using GITHUB_TOKEN.
-    #permissions:
-    #  contents: write
-    #  pull-requests: write
-
-    # Using a real user/email is recommended instead of using GITHUB_TOKEN, otherwise pull
-    # requests opened by this workflow, and commits pushed, will not queue your CI status checks.
-    # Similarly, the approve-and-merge workflow will also not run if GITHUB_TOKEN is used.
-    # See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
-    # The Git commit user name and email are set as variables in the organization or repository settings.
-    # See https://docs.github.com/en/actions/learn-github-actions/variables
     with:
       labels: "dependencies,.NET"
       user-email: ${{ vars.GIT_COMMIT_USER_EMAIL }}
       user-name: ${{ vars.GIT_COMMIT_USER_NAME }}
     secrets:
       repo-token: ${{ secrets.ACCESS_TOKEN }}
+```
+
+#### With a GitHub App
+
+This workflow uses a GitHub app to authenticate with GitHub and perform the updates.
+The app must have at least **Read and write** permissions for **Contents** and **Pull requests**
+to be able to push changes to the repository and open a pull request.
+
+See the [GitHub documentation][create-github-app] for more information on creating a GitHub app.
+
+```yaml
+name: update-dotnet-sdk
+
+on:
+
+  # Scheduled trigger to check for .NET SDK updates at 2000 UTC every
+  # Tuesday so that a run will coincide with monthly Update Tuesday releases
+  # for security and non-security improvements to the .NET SDK and runtime.
+  schedule:
+    - cron:  '00 20 * * TUE'
+
+  # Manual trigger to update the .NET SDK on-demand.
+  workflow_dispatch:
+
+# No additional permissions are required for GITHUB_TOKEN as we are using an app.
+permissions:
+  contents: read
+
+# The Git commit user name and email are set as variables in the organization or repository settings.
+# See https://docs.github.com/en/actions/learn-github-actions/variables.
+# You can obtain the user name and email for the GitHub app by running the following
+# command using the GitHub CLI (https://cli.github.com/) in a terminal and substituting the values as shown below:
+#
+# app_name="YOUR_GITHUB_APP_NAME"
+# echo "Git user name: ${app_name}[bot]"
+# echo "Git user email: $(gh api "/users/${app_name}[bot]" --jq ".id")+${app_name}[bot]@users.noreply.github.com"
+jobs:
+  update-sdk:
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@v2
+    with:
+      labels: "dependencies,.NET"
+      user-email: ${{ vars.GIT_COMMIT_USER_EMAIL }}
+      user-name: ${{ vars.GIT_COMMIT_USER_NAME }}
+    secrets:
+      application-id: ${{ secrets.UPDATER_APPLICATION_ID }}
+      application-private-key: ${{ secrets.UPDATER_APPLICATION_PRIVATE_KEY }}
+```
+
+#### With GITHUB_TOKEN
+
+This workflow uses the built-in `GITHUB_TOKEN` secret to authenticate with GitHub and
+perform the updates as GitHub Actions. The token must have at least `write` permissions
+for `contents` and `pull-requests` to be able to push changes to the repository and open
+a pull request.
+
+Using a real user/email is recommended instead of using `GITHUB_TOKEN`, otherwise pull
+requests opened by this workflow, and commits pushed, will not queue your CI status checks
+if you use GitHub Actions for your CI. More information about this restriction can be
+found [here][triggering-workflows-from-a-workflow].
+
+See the [GitHub documentation][github-token] for more information on `GITHUB_TOKEN`.
+
+```yaml
+name: update-dotnet-sdk
+
+on:
+
+  # Scheduled trigger to check for .NET SDK updates at 2000 UTC every
+  # Tuesday so that a run will coincide with monthly Update Tuesday releases
+  # for security and non-security improvements to the .NET SDK and runtime.
+  schedule:
+    - cron:  '00 20 * * TUE'
+
+  # Manual trigger to update the .NET SDK on-demand.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  update-sdk:
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@v2
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      labels: "dependencies,.NET"
+    secrets:
+      repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
@@ -144,10 +232,15 @@ The repository is hosted in [GitHub][update-dotnet-sdk]: <https://github.com/mar
 
 This project is licensed under the [Apache 2.0][license] license.
 
+[create-github-app]: https://docs.github.com/apps/creating-github-apps/creating-github-apps/creating-a-github-app
 [dotnet-outdated]: https://github.com/dotnet-outdated/dotnet-outdated
 [example-pull-request]: https://github.com/martincostello/update-dotnet-sdk/pull/10
+[github-apps]: https://docs.github.com/apps/creating-github-apps/creating-github-apps/about-apps
+[github-token]: https://docs.github.com/actions/security-guides/automatic-token-authentication
 [issues]: https://github.com/martincostello/update-dotnet-sdk/issues
 [license]: https://www.apache.org/licenses/LICENSE-2.0.txt
+[personal-access-token]: https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 [reusable-workflow]: https://github.com/martincostello/update-dotnet-sdk/blob/main/.github/workflows/update-dotnet-sdk.yml
 [reusable-workflow-docs]: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 [update-dotnet-sdk]: https://github.com/martincostello/update-dotnet-sdk
+[triggering-workflows-from-a-workflow]: https://docs.github.com/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ perform the updates as GitHub Actions. The token must have at least `write` perm
 for `contents` and `pull-requests` to be able to push changes to the repository and open
 a pull request.
 
-Using a real user/email is recommended instead of using `GITHUB_TOKEN`, otherwise pull
-requests opened by this workflow, and commits pushed, will not queue your CI status checks
-if you use GitHub Actions for your CI. More information about this restriction can be
-found [here][triggering-workflows-from-a-workflow].
+Using a personal access token or a GitHub app is recommended instead of using `GITHUB_TOKEN`,
+otherwise pull requests opened by this workflow, and commits pushed, will not queue your CI
+status checks if you use GitHub Actions for your CI. More information about this restriction
+can be found [here][triggering-workflows-from-a-workflow].
 
 See the [GitHub documentation][github-token] for more information on `GITHUB_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
 
 ### Advanced Workflow
 
-Below is an example of an advanced GitHub Actions workflow to automate .NET SDK updates that will
+Below are examples of an advanced GitHub Actions workflow to automate .NET SDK updates that will
 also use the [dotnet-outdated][dotnet-outdated] .NET Global Tool to update any NuGet packages
 for the current .NET SDK release channel that are available from NuGet.org if the .NET SDK is updated.
 
@@ -56,8 +56,10 @@ This workflow leverages a [GitHub reusable workflow][reusable-workflow-docs] tha
 in this repository, which can be found [here][reusable-workflow].
 
 The workflow supports being used with a GitHub [personal access token][personal-access-token],
-a [GitHub app][github-apps], or [`GITHUB_TOKEN`][github-token] (not recommended due to restrictions
-when [triggering a workflow from another workflow][triggering-workflows-from-a-workflow]).
+a [GitHub app][github-apps], or [`GITHUB_TOKEN`][github-token].
+
+> **Note**
+> Using `GITHUB_TOKEN` is not recommended due to restrictions when [triggering a workflow from another workflow][triggering-workflows-from-a-workflow].
 
 #### With a Personal Access Token
 
@@ -86,7 +88,7 @@ permissions:
   contents: read
 
 # The Git commit user name and email are set as variables in the organization or repository settings.
-# See https://docs.github.com/en/actions/learn-github-actions/variables.
+# See https://docs.github.com/actions/learn-github-actions/variables.
 jobs:
   update-sdk:
     uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@v2
@@ -125,7 +127,7 @@ permissions:
   contents: read
 
 # The Git commit user name and email are set as variables in the organization or repository settings.
-# See https://docs.github.com/en/actions/learn-github-actions/variables.
+# See https://docs.github.com/actions/learn-github-actions/variables.
 # You can obtain the user name and email for the GitHub app by running the following
 # command using the GitHub CLI (https://cli.github.com/) in a terminal and substituting the values as shown below:
 #
@@ -241,6 +243,6 @@ This project is licensed under the [Apache 2.0][license] license.
 [license]: https://www.apache.org/licenses/LICENSE-2.0.txt
 [personal-access-token]: https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 [reusable-workflow]: https://github.com/martincostello/update-dotnet-sdk/blob/main/.github/workflows/update-dotnet-sdk.yml
-[reusable-workflow-docs]: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+[reusable-workflow-docs]: https://docs.github.com/actions/using-workflows/reusing-workflows
 [update-dotnet-sdk]: https://github.com/martincostello/update-dotnet-sdk
 [triggering-workflows-from-a-workflow]: https://docs.github.com/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow


### PR DESCRIPTION
Add support to the reusable workflow for generating a token from a GitHub App instead of using a GitHub personal access token.

Also updates the README with lots of examples for using the workflow with different types of GitHub credentials.