### PR TITLE
Exclude NuGet package updates

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,5 +70,5 @@ jobs:
         ACTIONLINT_VERSION: '7b75d16d41920ec126e6f3269db0c6f3ab613c38' # v1.6.25
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"
-        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash)
+        bash <(curl "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash")
         ./actionlint -color

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,3 +55,20 @@ jobs:
       with:
         file: ./coverage/lcov.info
         flags: ${{ matrix.codecov_os }}
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+    - name: Lint GitHub Actions workflows
+      shell: bash
+      env:
+        ACTIONLINT_VERSION: '7b75d16d41920ec126e6f3269db0c6f3ab613c38' # v1.6.25
+      run: |
+        echo "::add-matcher::.github/actionlint-matcher.json"
+        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash)
+        ./actionlint -color

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: string
         default: 'Microsoft.AspNetCore.,Microsoft.EntityFrameworkCore.,Microsoft.Extensions.,System.Text.Json'
+      exclude-nuget-packages:
+        description: 'A comma-separated list of NuGet package IDs (or substrings) to not update if update-nuget-packages is true.'
+        required: false
+        type: string
+        default: ''
       user-email:
         description: 'The optional email address to use for the Git commit.'
         required: false
@@ -206,6 +211,21 @@ jobs:
         $tempPath = [System.IO.Path]::GetTempPath()
         $updatesPath = (Join-Path $tempPath "dotnet-outdated.json")
 
+        $eligiblePackages = "${{ inputs.include-nuget-packages }}".Split(',')
+        $ineligiblePackages = "${{ inputs.exclude-nuget-packages }}".Split(',')
+
+        $additionalArguments = @()
+
+        foreach ($package in $eligiblePackages) {
+          $additionalArguments += "--include"
+          $additionalArguments += $package
+        }
+
+        foreach ($package in $ineligiblePackages) {
+          $additionalArguments += "--exclude"
+          $additionalArguments += $package
+        }
+
         Write-Host "Checking for .NET NuGet package(s) to update..."
 
         # The --version-lock Major option is used to only update packages
@@ -213,19 +233,11 @@ jobs:
         # The --include flags are used to only update Microsoft-published
         # NuGet packages that are typically published with a new patch
         # release of .NET that accompanies a new .NET SDK release.
-        $eligiblePackages = "${{ inputs.include-nuget-packages }}".Split(',')
-        $includePackages = @()
-
-        foreach ($package in $eligiblePackages) {
-          $includePackages += "--include"
-          $includePackages += $package
-        }
-
         dotnet outdated `
           --upgrade `
           --version-lock Major `
           --output $updatesPath `
-          $includePackages
+          $additionalArguments
 
         $dependencies = @()
 


### PR DESCRIPTION
Add `exclude-nuget-packages` input to allow excluding packages from NuGet package updates with `dotnet outdated`.

Resolves #496.
