### PR TITLE
Fix checkout when running from another repo

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: ''
+      checkout-ref:
+        description: 'The optional branch, tag or SHA to checkout for the repository.'
+        required: false
+        type: string
+        default: ''
       commit-message:
         description: 'The optional Git commit message to use.'
         required: false
@@ -181,6 +186,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
+        ref: ${{ inputs.checkout-ref || '' }}
+        repository: ${{ inputs.repo || github.repository }}
         token: ${{ steps.assign-token.outputs.access-token }}
 
     # Run the action to check if a new version of the .NET SDK is available


### PR DESCRIPTION
When running the reusable workflow from a repository other than the target, the checkout action needs to use the appropriate values for the repo and ref.
