### PR TITLE
Re-enable daily channel tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "update-dotnet-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "update-dotnet-sdk",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-dotnet-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "description": "A GitHub Action that updates the .NET SDK.",
   "main": "lib/main.js",

--- a/tests/DotNetSdkUpdater.test.ts
+++ b/tests/DotNetSdkUpdater.test.ts
@@ -348,10 +348,8 @@ describe('DotNetSdkUpdater', () => {
     });
 
     describe.each([
-      /*
       ['8.0', 'daily'],
       ['8.0.1xx', 'daily'],
-      */
       ['8.0.1xx-preview7', 'daily'],
     ])('for channel %s and quality %s', (channel: string, quality: string) => {
       test(

--- a/tests/daily.test.ts
+++ b/tests/daily.test.ts
@@ -7,10 +7,8 @@ import { ActionFixture } from './ActionFixture';
 
 describe('update-dotnet-sdk', () => {
   describe.each([
-    /*
     ['daily', '8.0', '8.0.100-'],
     ['daily', '8.0.1xx', '8.0.100-'],
-    */
     ['daily', '8.0.1xx-preview7', '8.0.100-'],
   ])('for %s builds for channel "%s"', (quality: string, channel: string, expected: string) => {
     const sdkVersion = '8.0.100-preview.6.23330.14';


### PR DESCRIPTION
Re-enable tests now that 9.0 versions have been removed from the 8.0 channels.
