### PR TITLE
Avoid dotnet-outdated timeouts

### DIFF
--- a/.github/workflows/update-dotnet-sdk-test.yml
+++ b/.github/workflows/update-dotnet-sdk-test.yml
@@ -35,3 +35,4 @@ jobs:
         echo "Branch name: ${{ needs.update-sdk.outputs.branch-name }}"
         echo "PR number: ${{ needs.update-sdk.outputs.pull-request-number }}"
         echo "PR URL: ${{ needs.update-sdk.outputs.pull-request-html-url }}"
+        echo "PR(s) closed: ${{ needs.update-sdk.outputs.pull-requests-closed }}"

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -246,6 +246,7 @@ jobs:
       run: |
         $ErrorActionPreference = "Stop"
 
+        Write-Host "Installing dotnet-outdated-tool..."
         dotnet tool install --global dotnet-outdated-tool
 
         $tempPath = [System.IO.Path]::GetTempPath()
@@ -269,6 +270,12 @@ jobs:
             $additionalArguments += $package
           }
         }
+
+        # HACK Inspired by https://github.com/dotnet-outdated/dotnet-outdated/issues/55
+        # run dotnet restore to populate the NuGet package cache to try and avoid timeouts
+        # when dotnet-outdated is run
+        Write-Host "Restoring NuGet packages..."
+        dotnet restore
 
         Write-Host "Checking for .NET NuGet package(s) to update..."
 

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -67,6 +67,11 @@ on:
         required: false
         type: boolean
         default: true
+      dotnet-outdated-version:
+        description: 'The version of the dotnet-outdated .NET global tool to use if update-nuget-packages is true.'
+        required: false
+        type: string
+        default: '4.5.3'
       include-nuget-packages:
         description: 'A comma-separated list of NuGet package IDs (or substrings) to update, if update-nuget-packages is true.'
         required: false
@@ -247,7 +252,7 @@ jobs:
         $ErrorActionPreference = "Stop"
 
         Write-Host "Installing dotnet-outdated-tool..."
-        dotnet tool install --global dotnet-outdated-tool
+        dotnet tool install --global dotnet-outdated-tool --version "${{ inputs.dotnet-outdated-version || '*' }}"
 
         $tempPath = [System.IO.Path]::GetTempPath()
         $updatesPath = (Join-Path $tempPath "dotnet-outdated.json")


### PR DESCRIPTION
- Restore NuGet packages before running `dotnet-outdated` to try and avoid timeouts.
- Pin the version of dotnet-outdated to `4.5.3`, rather than always installing latest.
- Add `dotnet-outdated-version` input to allow the version to be changed.
- If no version is specified with an explicit parameter value, use `*`.
