### PR TITLE
Remove permissions

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -138,6 +138,8 @@ on:
 env:
   TERM: xterm
 
+permissions: {}
+
 jobs:
 
   update-dotnet-sdk:


### PR DESCRIPTION
Remove permissions as the default token passed in from the parent workflow should give the appropriate permissions as the token has to be explicitly passed in.
