### PR TITLE
Simplify type

### DIFF
--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -12,7 +12,7 @@ type Fixture = {
 
 type Scenario = {
   basePath: string;
-  method?: 'DELETE' | 'GET' | 'PATCH' | 'POST';
+  method?: string;
   headers?: Record<string, string>;
   path: string;
   persist?: boolean;


### PR DESCRIPTION
Simplify the property for a method to just a string as the strongly-typed methods of nock are no longer used.
