### PR TITLE
Update dotnet-outdated

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -71,7 +71,7 @@ on:
         description: 'The version of the dotnet-outdated .NET global tool to use if update-nuget-packages is true.'
         required: false
         type: string
-        default: '4.5.3'
+        default: '4.6.0'
       include-nuget-packages:
         description: 'A comma-separated list of NuGet package IDs (or substrings) to update, if update-nuget-packages is true.'
         required: false


### PR DESCRIPTION
Update the default dotnet-outdated version to 4.6.0.

<!-- Summarise the changes this Pull Request makes. -->

<!-- Please include a reference to a GitHub issue if appropriate. -->
