### PR TITLE
Restore .NET workloads before updating NuGet packages

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -315,6 +315,34 @@ jobs:
           dotnet tool restore
         }
 
+        # .NET workloads need to be restored before running dotnet outdated.
+        # This is only supported for .NET 8+ as earlier SDK versions do not support -getTargetResult.
+        if ([Version]::new($env:UPDATED_SDK_VERSION).Major -ge 8) {
+          $projectFiles = Get-ChildItem -Path "." -Filter "*.csproj" -Recurse
+          $projectFiles += Get-ChildItem -Path "." -Filter "*.fsproj" -Recurse
+          $projectFiles += Get-ChildItem -Path "." -Filter "*.vbproj" -Recurse
+
+          $restoreWorkloads = $false
+          $targetName = "_GetRequiredWorkloads"
+
+          foreach ($project in $projectFiles) {
+            # See https://github.com/dotnet/sdk/blob/051c52977e668544b58f60ff4d4ff84fe67d33f2/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs#L46-L81
+            $targetsResult = dotnet msbuild $project.FullName "-getTargetResult:${targetName}"
+            if (-Not [string]::IsNullOrEmpty($targetsResult)) {
+              $json = $targetsResult | ConvertFrom-Json
+              if ($json.TargetResults -And ($json.TargetResults.$targetName.Items.Count -gt 0)) {
+                $restoreWorkloads = $true
+                break
+              }
+            }
+          }
+
+          if ($restoreWorkloads) {
+            Write-Host "Restoring .NET workloads..."
+            dotnet workload restore
+          }
+        }
+
         # HACK Inspired by https://github.com/dotnet-outdated/dotnet-outdated/issues/55
         # run dotnet restore to populate the NuGet package cache to try and avoid timeouts
         # when dotnet-outdated is run

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -327,7 +327,7 @@ jobs:
 
           foreach ($project in $projectFiles) {
             # See https://github.com/dotnet/sdk/blob/051c52977e668544b58f60ff4d4ff84fe67d33f2/src/Cli/dotnet/commands/dotnet-workload/restore/WorkloadRestoreCommand.cs#L46-L81
-            $targetsResult = dotnet msbuild $project.FullName "-getTargetResult:${targetName}"
+            $targetsResult = dotnet msbuild $project.FullName "-getTargetResult:${targetName}" "-property:SkipResolvePackageAssets=true"
             if (-Not [string]::IsNullOrEmpty($targetsResult)) {
               $json = $targetsResult | ConvertFrom-Json
               if ($json.TargetResults -And ($json.TargetResults.$targetName.Items.Count -gt 0)) {

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -317,7 +317,7 @@ jobs:
 
         # .NET workloads need to be restored before running dotnet outdated.
         # This is only supported for .NET 8+ as earlier SDK versions do not support -getTargetResult.
-        if ([Version]::new($env:UPDATED_SDK_VERSION).Major -ge 8) {
+        if ([Version]::new(${env:UPDATED_SDK_VERSION}.Split("-")[0]).Major -ge 8) {
           $projectFiles = Get-ChildItem -Path "." -Filter "*.csproj" -Recurse
           $projectFiles += Get-ChildItem -Path "." -Filter "*.fsproj" -Recurse
           $projectFiles += Get-ChildItem -Path "." -Filter "*.vbproj" -Recurse


### PR DESCRIPTION
Fix NuGet package updates failing if the project contains projects that require any .NET workloads, such as .NET Aspire ([example](https://github.com/martincostello/github-automation/actions/runs/8782179665/job/24095861524#step:8:154)), due to [NETSDK1147](https://learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1147) errors.
