### PR TITLE
Bump dotnet-outdated

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -76,7 +76,7 @@ on:
         description: 'The version of the dotnet-outdated .NET global tool to use if update-nuget-packages is true.'
         required: false
         type: string
-        default: '4.6.1'
+        default: '4.6.4'
       include-nuget-packages:
         description: 'A comma-separated list of NuGet package IDs (or substrings) to update, if update-nuget-packages is true.'
         required: false


### PR DESCRIPTION
Update the default version of dotnet-outdated-tool to v4.6.4 now that issues with the JSON report are resolved.