### PR TITLE
Fail workflow if commands fail

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -287,7 +287,7 @@ jobs:
 
         if ($LASTEXITCODE -ne 0) {
           Write-Host "dotnet tool install failed with code ${LASTEXITCODE}"
-          return 1
+          exit 1
         }
 
         $tempPath = [System.IO.Path]::GetTempPath()
@@ -326,7 +326,7 @@ jobs:
           dotnet tool restore
           if ($LASTEXITCODE -ne 0) {
             Write-Host "dotnet tool restore failed with code ${LASTEXITCODE}"
-            return 1
+            exit 1
           }
         }
 
@@ -358,7 +358,7 @@ jobs:
             dotnet workload restore
             if ($LASTEXITCODE -ne 0) {
               Write-Host "dotnet workfload restore failed with code ${LASTEXITCODE}"
-              return 1
+              exit 1
             }
           }
         }
@@ -371,7 +371,7 @@ jobs:
 
         if ($LASTEXITCODE -ne 0) {
           Write-Host "dotnet restore failed with code ${LASTEXITCODE}"
-          return 1
+          exit 1
         }
 
         Write-Host "Checking for .NET NuGet package(s) to update..."
@@ -389,7 +389,7 @@ jobs:
 
         if ($LASTEXITCODE -ne 0) {
           Write-Host "dotnet outdated failed with code ${LASTEXITCODE}"
-          return 1
+          exit 1
         }
 
         $dependencies = @()

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -286,7 +286,7 @@ jobs:
         dotnet tool install --global dotnet-outdated-tool --version "$env:DOTNET_OUTDATED_VERSION"
 
         if ($LASTEXITCODE -ne 0) {
-          Write-Host "dotnet tool install failed with code ${LASTEXITCODE}"
+          Write-Output "::error::dotnet tool install failed with code ${LASTEXITCODE}"
           exit 1
         }
 
@@ -325,7 +325,7 @@ jobs:
           Write-Host "Restoring .NET tools..."
           dotnet tool restore
           if ($LASTEXITCODE -ne 0) {
-            Write-Host "dotnet tool restore failed with code ${LASTEXITCODE}"
+            Write-Output "::error::dotnet tool restore failed with code ${LASTEXITCODE}"
             exit 1
           }
         }
@@ -357,7 +357,7 @@ jobs:
             Write-Host "Restoring .NET workloads..."
             dotnet workload restore
             if ($LASTEXITCODE -ne 0) {
-              Write-Host "dotnet workfload restore failed with code ${LASTEXITCODE}"
+              Write-Output "::error::dotnet workfload restore failed with code ${LASTEXITCODE}"
               exit 1
             }
           }
@@ -370,7 +370,7 @@ jobs:
         dotnet restore
 
         if ($LASTEXITCODE -ne 0) {
-          Write-Host "dotnet restore failed with code ${LASTEXITCODE}"
+          Write-Output "::error::dotnet restore failed with code ${LASTEXITCODE}"
           exit 1
         }
 
@@ -388,7 +388,7 @@ jobs:
           $additionalArguments
 
         if ($LASTEXITCODE -ne 0) {
-          Write-Host "dotnet outdated failed with code ${LASTEXITCODE}"
+          Write-Output "::error::dotnet outdated failed with code ${LASTEXITCODE}"
           exit 1
         }
 


### PR DESCRIPTION
Fix intended functionality from #1081 not working due to using `return` instead of `exit`.
