### PR TITLE
Allow DOTNET_ROLL_FORWARD to be specified

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: ''
+      dotnet-roll-forward:
+        description: 'An optional value that controls how roll forward is applied to any .NET tools run by the workflow.'
+        required: false
+        type: string
+        default: 'Minor'
       generate-step-summary:
         description: 'If true, will output a summary of any .NET SDK update to $GITHUB_STEP_SUMMARY.'
         required: false
@@ -272,6 +277,7 @@ jobs:
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_NOLOGO: true
         DOTNET_OUTDATED_VERSION: ${{ inputs.dotnet-outdated-version || '*' }}
+        DOTNET_ROLL_FORWARD: ${{ inputs.dotnet-roll-forward }}
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
         DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
         EXCLUDE_NUGET_PACKAGES: ${{ inputs.exclude-nuget-packages }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "update-dotnet-sdk",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "update-dotnet-sdk",
-      "version": "3.6.1",
+      "version": "3.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-dotnet-sdk",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "private": true,
   "description": "A GitHub Action that updates the .NET SDK.",
   "main": "lib/main.js",


### PR DESCRIPTION
Add a new input, `dotnet-roll-forward`, that configures `DOTNET_ROLL_FORWARD` when updating NuGet packages to enable using daily .NET builds with tools such as dotnet-outdated-tool.
