### PR TITLE
Update deprecated action input

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -219,7 +219,7 @@ jobs:
       if: steps.validate-secrets.outputs.result == 'true'
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.application-id }}
+        client-id: ${{ secrets.application-id }}
         owner: ${{ inputs.organization }}
         permission-contents: write
         permission-pull-requests: write


### PR DESCRIPTION
`app-id` was deprecated in 3.1.0 in favour of `client-id`.
