### PR TITLE
Specify repositories to create-github-app-token

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -220,10 +220,11 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         client-id: ${{ secrets.application-id }}
-        owner: ${{ inputs.organization }}
+        owner: ${{ inputs.organization || github.repository_owner }}
         permission-contents: write
         permission-pull-requests: write
         private-key: ${{ secrets.application-private-key }}
+        repositories: ${{ inputs.repo || github.repository }}
 
     - name: Assign GitHub token
       id: assign-token


### PR DESCRIPTION
When `owner` is specified, actions/create-github-app-token will create a token with permissions to every repository the GitHub App has access to in that organization. Reduce the token's scope by explicitly specifying the repository.

Resolves https://github.com/martincostello/update-dotnet-sdk/security/code-scanning/133.
