### PR TITLE
Use self-repository syntax

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -57,6 +57,6 @@ jobs:
         git commit -m "Add global.json for .NET SDK version ${env:DOTNET_VERSION}" -s
 
     - name: Update .NET SDK
-      uses: ./
+      uses: $/
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use [new self-repository syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) to refer to this action for self-testing.

Depends on https://github.com/rhysd/actionlint/issues/711.